### PR TITLE
Add __init__.__version__ to version checking

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -93,11 +93,11 @@ checkout_release () {
 # Update the version numbers in canonical locations.
 update_versions () {
     # maxdepth, so we don't pull things from .tox, etc
-    if [ $VERSION_FILE="settings.py" ]; then
+    if [ $VERSION_FILE = "settings.py" ]; then
       find $WORKING_DIR -maxdepth 2 -name 'settings.py' | xargs perl -pi -e "s/VERSION = .*/VERSION = \"$VERSION\"/g"
-    elif [ $VERSION_FILE="__init__.py" ]; then
-      find $WORKING_DIR -maxdepth 2 -name '__init__.py' | xargs perl -pi -e "s/__version__=.*/__version__='$VERSION',/g"
-    elif [ $VERSION_FILE="setup.py" ]; then
+    elif [ $VERSION_FILE = "__init__.py" ]; then
+      find $WORKING_DIR -maxdepth 2 -name '__init__.py' | xargs perl -pi -e "s/__version__\ ?=.*#\ pragma:\ no\ cover/__version__\ =\ '$VERSION'\ \ #\ pragma:\ no\ cover/g"
+    elif [ $VERSION_FILE = "setup.py" ]; then
       find $WORKING_DIR -maxdepth 2 -name 'setup.py' | xargs perl -pi -e "s/version=.*/version='$VERSION',/g"
     else
       error "Could not update with new version."
@@ -131,11 +131,9 @@ update_release_notes () {
         echo $line >> releases_rst.new
     done;
     echo '' >> releases_rst.new
-    if [[ ! -f "RELEASE.rst" ]]; then
-      echo "Creating RELEASE.rst"
-      touch RELEASE.rst
+    if [[ -f RELEASE.rst ]]; then
+      cat RELEASE.rst | tail -n +4 >> releases_rst.new
     fi
-    cat RELEASE.rst | tail -n +4 >> releases_rst.new
     mv releases_rst.new RELEASE.rst
     # explicit add, because we know the location & we will need it for the first release
     git add RELEASE.rst

--- a/release.sh
+++ b/release.sh
@@ -65,16 +65,19 @@ validate_dependencies () {
 
 set_old_version () {
     echo "Defining old version..."
-    OLD_VERSION="$(find $WORKING_DIR -maxdepth 2 -name 'settings.py' | xargs grep VERSION | tr "\"" ' ' | tr "'" " " | awk 'NR==1{print $3}')"
-    VERSION_FILE="settings.py"
-    if [[ -z "$OLD_VERSION" ]]; then
-      OLD_VERSION="$(find $WORKING_DIR -maxdepth 2 -name '__init__.py' | xargs grep __version__ | tr "\"" ' ' | tr "'" " " | awk '{print $3}')"
-      VERSION_FILE="__init__.py"
-    fi
-    if [[ -z "$OLD_VERSION" ]]; then
-      OLD_VERSION="$(find $WORKING_DIR -maxdepth 2 -name 'setup.py' | xargs grep version | tr "\"" ' ' | tr "'" " " | awk '{print $3}')"
-      VERSION_FILE="setup.py"
-    fi
+    OLD_VERSION=""
+    version_files=( 'settings.py' '__init__.py' 'setup.py' )
+    for file_name in "${version_files[@]}"
+    do
+        OLD_VERSION="$(find $WORKING_DIR -maxdepth 2 -name "$file_name" | xargs grep -i version | tr " =" " " | tr "\"" ' ' | tr "'" " " | awk 'NR==1{print $2}')"
+        VERSION_FILE="$file_name"
+
+        if [[ ! -z "$OLD_VERSION" ]]; then
+            break
+        fi
+
+    done
+
     if [[ -z "$OLD_VERSION" ]]; then
       error "Could not determine the old version."
       exit 1


### PR DESCRIPTION
**What are the relevant tickets?**

**What's this PR do?**
The release-script determines the current version number by examining likely source files such as `settings.py` and `setup.py`.  If the project has neither of these files, the script will fail.

This feature adds support for using the package `__init__` file, examining it for the variable `__version__`.  If the variable is found, it is used to set the current version number.

**Where should the reviewer start?**

**How should this be manually tested?**

**What GIF best describes this PR or how it makes you feel?**

**Any background context you want to provide?**

**What GIF best describes this PR or how it makes you feel?**

@giocalitri @pdpinch 
