### PR TITLE
Fixed relative path reference to release.sh

### DIFF
--- a/finish_release.sh
+++ b/finish_release.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-. ./release.sh
+# Quote nesting works as described here: http://stackoverflow.com/a/6612417/4972
+# SCRIPT_DIR via http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $SCRIPT_DIR/release.sh
 
 merge_release_candidate (){
     echo "Merge release-candidate into release"


### PR DESCRIPTION
There is a reference to `./release.sh` in `./finish_release.sh`. This means we can't run `finish_release.sh` from any directory other than the home directory of `release-script`. This PR attempts to fix that