### PR TITLE
Fixed lookup of release manager name

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -19,7 +19,7 @@ def release_manager_name():
     lines = check_output(["git", "config", "--global", "-l"]).decode().split("\n")
     for line in lines:
         pieces = line.split("=")
-        if len(pieces) == 2:
+        if len(pieces) == 2 and pieces[0] == 'user.name':
             return pieces[1]
     return None
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #50

#### What's this PR do?
Returns the git config line for `user.name`

#### How should this be manually tested?
in a python shell:
```python
import bot
bot.release_manager_name()
```