### PR TITLE
Validate repo for wait_for_checked.py

### DIFF
--- a/wait_for_checked.py
+++ b/wait_for_checked.py
@@ -14,9 +14,13 @@ def main():
     parser.add_argument("--org", default="mitodl")
     args = parser.parse_args()
 
+    if "." in args.repo or "/" in args.repo:
+        raise Exception("repo is just the repo name, not a URL or directory (ie 'micromasters')")
+
     loop = asyncio.get_event_loop()
     loop.run_until_complete(wait_for_checkboxes(args.org, args.repo, args.version))
     loop.close()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Checks that the repo argument for `wait_for_checked.py` is not actually a directory or URL

#### How should this be manually tested?
Run `wait_for_checked.py ../micromasters 3.4.5` and verify that you see the error message