### PR TITLE
Make version update slightly less sensitive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.5"
+  - "3.6"
 node_js:
   - "6.2"
 install:

--- a/release.py
+++ b/release.py
@@ -108,8 +108,8 @@ def update_version_in_file(root, filename, new_version):
                     )
                 elif filename == "__init__.py":
                     updated_line = re.sub(
-                        "__version__ ?=.*# pragma: no cover",
-                        "__version__ = '{version}'  # pragma: no cover".format(version=new_version),
+                        "__version__ ?=.*",
+                        "__version__ = '{version}'".format(version=new_version),
                         line,
                     )
                 elif filename == "setup.py":

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35
+envlist = py36
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Makes the regex for detecting the version in `__init__.py` ignore the suffix. We generally don't mark lines as ignoring coverage anymore, and edx_sga requires this fix to do the release

#### How should this be manually tested?
Open a python shell and run this code:

    from release import init_working_dir, update_version
    with init_working_dir("git@github.com:mitodl/edx-sga.git"):
        old_version = update_version("9.9.9")
        new_version = update_version("9.9.9")
        if new_version != "9.9.9":
            raise Exception()

If you're on `master` you should see an exception, and if you're on this branch you should not see an exception