### PR TITLE
Don't require version numbers for finish_release or wait_for_checkboxes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -29,6 +29,8 @@ from release import (
 from lib import (
     get_org_and_repo,
     get_release_pr,
+    get_release_pr_version,
+    get_release_pr_url,
     get_unchecked_authors,
     match_user,
     next_workday_at_10,
@@ -153,6 +155,10 @@ class Bot:
         """
         repo_url = repo_info.repo_url
         channel_id = repo_info.channel_id
+        org, repo = get_org_and_repo(repo_url)
+        pr = get_release_pr(org, repo)
+        if pr:
+            raise ReleaseException("A release is already in progress: {}".format(get_release_pr_url(pr)))
         release(repo_url, version)
 
         await self.say(
@@ -164,8 +170,7 @@ class Bot:
         )
 
         await wait_for_deploy(repo_url, repo_info.rc_hash_url, "release-candidate")
-        org, repo = get_org_and_repo(repo_url)
-        unchecked_authors = get_unchecked_authors(org, repo, version)
+        unchecked_authors = get_unchecked_authors(org, repo)
         slack_usernames = self.translate_slack_usernames(unchecked_authors)
         await self.say(
             channel_id,
@@ -173,18 +178,17 @@ class Bot:
             " These people have commits in this release: {authors}".format(
                 version=version,
                 authors=", ".join(slack_usernames),
-                pr_url=get_release_pr(org, repo, version)['html_url'],
+                pr_url=get_release_pr_url(get_release_pr(org, repo)),
                 project=repo_info.name,
             )
         )
 
-    async def wait_for_checkboxes(self, repo_info, version):
+    async def wait_for_checkboxes(self, repo_info):
         """
         Poll the Release PR and wait until all checkboxes are checked off
 
         Args:
             repo_info (RepoInfo): Information for a repo
-            version (str): The version
         """
         channel_id = repo_info.channel_id
         await self.say(
@@ -195,26 +199,32 @@ class Bot:
             )
         )
         org, repo = get_org_and_repo(repo_info.repo_url)
-        await wait_for_checkboxes(org, repo, version)
+        await wait_for_checkboxes(org, repo)
         release_manager = release_manager_name()
+        pr = get_release_pr(org, repo)
         await self.say(
             channel_id,
             "All checkboxes checked off. Release {version} is ready for the Merginator{name}!".format(
-                version=version,
                 name=' {}'.format(self.translate_slack_usernames([release_manager])[0]) if release_manager else '',
+                version=get_release_pr_version(pr)
             )
         )
 
-    async def finish_release(self, repo_info, version):
+    async def finish_release(self, repo_info):
         """
         Merge the release candidate into the release branch, tag it, merge to master, and wait for deployment
 
         Args:
             repo_info (RepoInfo): The info for a repo
-            version (str): The version
         """
         channel_id = repo_info.channel_id
         repo_url = repo_info.repo_url
+        org, repo = get_org_and_repo(repo_url)
+        pr = get_release_pr(org, repo)
+        if not pr:
+            raise ReleaseException("No release currently in progress for {project}".format(project=repo_info.name))
+        version = get_release_pr_version(pr)
+
         finish_release(repo_url, version)
 
         await self.say(
@@ -253,16 +263,15 @@ class Bot:
             ),
         )
 
-    async def message_if_unchecked(self, repo_info, version):
+    async def message_if_unchecked(self, repo_info):
         """
         Send a message next morning if any boxes are not yet checked off
 
         Args:
             repo_info (RepoInfo): Information for a repo
-            version (str): The version of the release to check
         """
         org, repo = get_org_and_repo(repo_info.repo_url)
-        unchecked_authors = get_unchecked_authors(org, repo, version)
+        unchecked_authors = get_unchecked_authors(org, repo)
         if unchecked_authors:
             slack_usernames = self.translate_slack_usernames(unchecked_authors)
             await self.say(
@@ -274,18 +283,17 @@ class Bot:
                 )
             )
 
-    async def delay_message(self, repo_info, version):
+    async def delay_message(self, repo_info):
         """
         sleep until 10am next day, then message
 
         Args:
             repo_info (RepoInfo): The info for a repo
-            version (str): The version number for the release
         """
         now = datetime.now()
         tomorrow_at_10 = next_workday_at_10(now)
         await asyncio.sleep((tomorrow_at_10 - now).total_seconds())
-        await self.message_if_unchecked(repo_info, version)
+        await self.message_if_unchecked(repo_info)
 
     async def handle_message(self, channel_id, repo_info, words, loop):
         """
@@ -304,16 +312,13 @@ class Bot:
             elif has_command(['release'], words) or has_command(['start', 'release'], words):
                 version = get_version_number(words[-1])
 
-                loop.create_task(self.delay_message(repo_info, version))
+                loop.create_task(self.delay_message(repo_info))
                 await self.do_release(repo_info, version)
-                await self.wait_for_checkboxes(repo_info, version)
+                await self.wait_for_checkboxes(repo_info)
             elif has_command(['finish', 'release'], words):
-                version = get_version_number(words[-1])
-
-                await self.finish_release(repo_info, version)
+                await self.finish_release(repo_info)
             elif has_command(['wait', 'for', 'checkboxes'], words):
-                version = get_version_number(words[-1])
-                await self.wait_for_checkboxes(repo_info, version)
+                await self.wait_for_checkboxes(repo_info)
             elif has_command(['hi'], words):
                 await self.say(
                     channel_id,

--- a/bot.py
+++ b/bot.py
@@ -178,7 +178,7 @@ class Bot:
             " These people have commits in this release: {authors}".format(
                 version=version,
                 authors=", ".join(slack_usernames),
-                pr_url=get_release_pr_url(get_release_pr(org, repo)),
+                pr_url=get_release_pr_url(pr),
                 project=repo_info.name,
             )
         )

--- a/bot.py
+++ b/bot.py
@@ -387,6 +387,7 @@ def main():
     resp = requests.post("https://slack.com/api/rtm.connect", data={
         "token": bot_access_token,
     })
+    resp.raise_for_status()
     doof_id = resp.json()['self']['id']
 
     async def connect_to_message_server(loop):

--- a/bot.py
+++ b/bot.py
@@ -29,8 +29,6 @@ from release import (
 from lib import (
     get_org_and_repo,
     get_release_pr,
-    get_release_pr_version,
-    get_release_pr_url,
     get_unchecked_authors,
     match_user,
     next_workday_at_10,
@@ -158,7 +156,7 @@ class Bot:
         org, repo = get_org_and_repo(repo_url)
         pr = get_release_pr(org, repo)
         if pr:
-            raise ReleaseException("A release is already in progress: {}".format(get_release_pr_url(pr)))
+            raise ReleaseException("A release is already in progress: {}".format(pr.url))
         release(repo_url, version)
 
         await self.say(
@@ -178,7 +176,7 @@ class Bot:
             " These people have commits in this release: {authors}".format(
                 version=version,
                 authors=", ".join(slack_usernames),
-                pr_url=get_release_pr_url(pr),
+                pr_url=pr.url,
                 project=repo_info.name,
             )
         )
@@ -206,7 +204,7 @@ class Bot:
             channel_id,
             "All checkboxes checked off. Release {version} is ready for the Merginator{name}!".format(
                 name=' {}'.format(self.translate_slack_usernames([release_manager])[0]) if release_manager else '',
-                version=get_release_pr_version(pr)
+                version=pr.version
             )
         )
 
@@ -223,7 +221,7 @@ class Bot:
         pr = get_release_pr(org, repo)
         if not pr:
             raise ReleaseException("No release currently in progress for {project}".format(project=repo_info.name))
-        version = get_release_pr_version(pr)
+        version = pr.version
 
         finish_release(repo_url, version)
 

--- a/lib.py
+++ b/lib.py
@@ -136,7 +136,7 @@ def get_unchecked_authors(org, repo):
     release_pr = get_release_pr(org, repo)
     if not release_pr:
         raise ReleaseException("No release PR found")
-    body = release_pr['body']
+    body = release_pr.body
     commits = parse_checkmarks(body)
     return {commit['author_name'] for commit in commits if not commit['checked']}
 

--- a/lib.py
+++ b/lib.py
@@ -1,5 +1,6 @@
 """Shared functions for release script Python files"""
 import asyncio
+from collections import namedtuple
 from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 import re
@@ -9,6 +10,9 @@ import sys
 import requests
 
 from exception import ReleaseException
+
+
+ReleasePR = namedtuple("ReleasePR", ['version', 'url', 'body'])
 
 
 def release_manager_name():
@@ -65,59 +69,60 @@ def parse_checkmarks(body):
     return commits
 
 
+def _get_pr(org, repo, branch):
+    """
+    Look up the pull request for a branch
+
+    Args:
+        org (str): The github organization (eg mitodl)
+        repo (str): The github repository (eg micromasters)
+        branch (str): The name of the associated branch
+
+    Returns:
+        dict: The information about the pull request
+    """
+    response = requests.get("https://api.github.com/repos/{org}/{repo}/pulls".format(
+        org=org,
+        repo=repo,
+    ))
+    response.raise_for_status()
+    pulls = response.json()
+    pulls = [pull for pull in pulls if pull['head']['ref'] == branch]
+    if len(pulls) == 0:
+        return None
+    elif len(pulls) > 1:
+        # Shouldn't happen since we look up by branch
+        raise Exception("More than one pull request for the branch {}".format(branch))
+
+    return pulls[0]
+
+
 def get_release_pr(org, repo):
     """
-    Look up the release pull request
+    Look up the pull request information for a release, or return None if it doesn't exist
 
     Args:
         org (str): The github organization (eg mitodl)
         repo (str): The github repository (eg micromasters)
 
     Returns:
-        dict: The information about the release pull request
+        ReleasePR: The information about the release pull request, or None if there is no release PR in progress
     """
-    pulls = requests.get("https://api.github.com/repos/{org}/{repo}/pulls".format(
-        org=org,
-        repo=repo,
-    )).json()
-    release_pulls = [pull for pull in pulls if pull['head']['ref'] == "release-candidate"]
-    if len(release_pulls) == 0:
+    pr = _get_pr(org, repo, 'release-candidate')
+    if pr is None:
         return None
-    elif len(release_pulls) > 1:
-        # Shouldn't happen since we look up by branch
-        raise Exception("More than one release pull request open at the same time")
 
-    return release_pulls[0]
-
-
-def get_release_pr_url(release_pr):
-    """
-    Look up the URL for the release pull request
-
-    Args:
-        release_pr (dict): The release PR info
-
-    Returns:
-        str: The URL for the release
-    """
-    return release_pr['html_url']
-
-
-def get_release_pr_version(release_pr):
-    """
-    Get the version for the release PR
-
-    Args:
-        release_pr (dict): The release PR info
-
-    Returns:
-        str: The version for the release
-    """
-    title = release_pr['title']
+    title = pr['title']
     match = re.match(r'^Release (?P<version>\d+\.\d+\.\d+)$', title)
     if not match:
         raise ReleaseException("Release PR title has an unexpected format")
-    return match.group('version')
+    version = match.group('version')
+
+    return ReleasePR(
+        version=version,
+        body=pr['body'],
+        url=pr['html_url'],
+    )
 
 
 def get_unchecked_authors(org, repo):

--- a/lib_test.py
+++ b/lib_test.py
@@ -17,6 +17,7 @@ from lib import (
     parse_checkmarks,
     reformatted_full_name,
     release_manager_name,
+    ReleasePR,
 )
 
 
@@ -127,7 +128,12 @@ def test_get_unchecked_authors():
     """
     org = 'org'
     repo = 'repo'
-    with patch('lib.get_release_pr', autospec=True, return_value=RELEASE_PR) as get_release_pr_mock:
+
+    with patch('lib.get_release_pr', autospec=True, return_value=ReleasePR(
+        body=FAKE_RELEASE_PR_BODY,
+        version='1.2.3',
+        url='http://url'
+    )) as get_release_pr_mock:
         unchecked = get_unchecked_authors(org, repo)
     assert unchecked == {"Alice Pote"}
     get_release_pr_mock.assert_called_once_with(org, repo)

--- a/wait_for_checked.py
+++ b/wait_for_checked.py
@@ -10,7 +10,6 @@ def main():
     """Wait for all checkboxes to get checked off"""
     parser = argparse.ArgumentParser()
     parser.add_argument("repo")
-    parser.add_argument("version")
     parser.add_argument("--org", default="mitodl")
     args = parser.parse_args()
 
@@ -18,7 +17,7 @@ def main():
         raise Exception("repo is just the repo name, not a URL or directory (ie 'micromasters')")
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(wait_for_checkboxes(args.org, args.repo, args.version))
+    loop.run_until_complete(wait_for_checkboxes(args.org, args.repo))
     loop.close()
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #71
Fixes #75 

#### What's this PR do?
Looks up the version number from the current release instead of requiring it as input

#### How should this be manually tested?
Run a release
