### PR TITLE
Replace hub with API call to create a PR, add package.json to install git-release-notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 htmlcov/
 .env_vars
 *.pyc
+package-lock.json
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
   - "6.2"
 install:
  - pip install -r test_requirements.txt
- - npm install -g git-release-notes
+ - npm install
 
 script: tox && coverage xml && codecov

--- a/app.json
+++ b/app.json
@@ -4,6 +4,9 @@
   "buildpacks": [
     {
       "url": "https://github.com/heroku/heroku-buildpack-python"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
     }
   ],
   "description": "Release script for MIT ODL engineering projects",

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,6 @@
 """Slack bot for managing releases"""
 
 import asyncio
-from collections import namedtuple
 from datetime import datetime
 import os
 import sys
@@ -38,16 +37,8 @@ from lib import (
     release_manager_name,
     wait_for_checkboxes,
 )
+from repo_info import RepoInfo
 from wait_for_deploy import wait_for_deploy
-
-
-RepoInfo = namedtuple('RepoInfo', [
-    'name',
-    'repo_url',
-    'rc_hash_url',
-    'prod_hash_url',
-    'channel_id',
-])
 
 
 log = logging.getLogger(__name__)
@@ -204,7 +195,7 @@ class Bot:
         pr = get_release_pr(org, repo)
         if pr:
             raise ReleaseException("A release is already in progress: {}".format(pr.url))
-        release(repo_url, version)
+        release(self.github_access_token, repo_url, version)
 
         await self.say(
             channel_id,

--- a/github.py
+++ b/github.py
@@ -6,6 +6,8 @@ import json
 from dateutil.parser import parse
 import requests
 
+from lib import get_org_and_repo
+
 
 KARMA_QUERY = """
 query {
@@ -92,6 +94,37 @@ def run_query(github_access_token, query):
     })
     resp.raise_for_status()
     return resp.json()
+
+
+def create_pr(github_access_token, repo_url, title, body, head, base):  # pylint: disable=too-many-arguments
+    """
+    Create a pull request
+
+    Args:
+        github_access_token (str): A github access token
+        repo_url (str): The URL of the repository to create the PR in
+        title (str): The title of the PR
+        body (str): The body of the PR
+        head (str): The head branch for the PR
+        base (str): The base branch for the PR
+    """
+
+    org, repo = get_org_and_repo(repo_url)
+    endpoint = "https://api.github.com/repos/mitodl/{org}/{repo}/pulls".format(
+        org=org,
+        repo=repo,
+    )
+
+    resp = requests.post(endpoint, headers={
+        "Authorization": "Bearer {}".format(github_access_token),
+        "Accept": "application/vnd.github.v3+json",
+    }, data={
+        'title': title,
+        'body': body,
+        'head': head,
+        'base': base,
+    })
+    resp.raise_for_status()
 
 
 def calculate_karma(github_access_token, begin_date, end_date):

--- a/github.py
+++ b/github.py
@@ -110,7 +110,7 @@ def create_pr(github_access_token, repo_url, title, body, head, base):  # pylint
     """
 
     org, repo = get_org_and_repo(repo_url)
-    endpoint = "https://api.github.com/repos/mitodl/{org}/{repo}/pulls".format(
+    endpoint = "https://api.github.com/repos/{org}/{repo}/pulls".format(
         org=org,
         repo=repo,
     )

--- a/github.py
+++ b/github.py
@@ -118,12 +118,12 @@ def create_pr(github_access_token, repo_url, title, body, head, base):  # pylint
     resp = requests.post(endpoint, headers={
         "Authorization": "Bearer {}".format(github_access_token),
         "Accept": "application/vnd.github.v3+json",
-    }, data={
+    }, data=json.dumps({
         'title': title,
         'body': body,
         'head': head,
         'base': base,
-    })
+    }))
     resp.raise_for_status()
 
 

--- a/github_test.py
+++ b/github_test.py
@@ -7,6 +7,7 @@ from dateutil.parser import parse
 
 from bot import SCRIPT_DIR
 from github import (
+    create_pr,
     calculate_karma,
     needs_review,
     KARMA_QUERY,
@@ -74,3 +75,37 @@ def test_needs_review():
             ),
         ]
     patched.assert_called_once_with(github_access_token, NEEDS_REVIEW_QUERY)
+
+
+def test_create_pr():
+    """create_pr should create a pr or raise an exception if the attempt failed"""
+    access_token = 'github_access_token'
+    org = 'abc'
+    repo = 'xyz'
+    title = 'title'
+    body = 'body'
+    head = 'head'
+    base = 'base'
+    with patch('requests.post', autospec=True) as patched:
+        create_pr(
+            access_token,
+            'https://github.com/{}/{}.git'.format(org, repo),
+            title,
+            body,
+            head,
+            base,
+        )
+    endpoint = 'https://api.github.com/repos/{}/{}/pulls'.format(org, repo)
+    patched.assert_called_once_with(
+        endpoint,
+        headers={
+            "Authorization": "Bearer {}".format(access_token),
+            "Accept": "application/vnd.github.v3+json",
+        },
+        data=json.dumps({
+            'title': title,
+            'body': body,
+            'head': head,
+            'base': base,
+        })
+    )

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "odl-release-bot",
+  "version": "0.0.0",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mitodl/release-script.git"
+  },
+  "dependencies": {
+    "git-release-notes": "^2.1.0"
+  }
+}

--- a/release.py
+++ b/release.py
@@ -226,15 +226,11 @@ def generate_release_pr(github_access_token, repo_url, old_version, new_version)
     """
     print("Generating PR...")
 
-    checklist_header = "Release {version}\n\n".format(version=new_version)
-    checklist_body = create_release_notes(old_version, with_checkboxes=True)
-    checklist = "{}{}".format(checklist_header, checklist_body)
-
     create_pr(
         github_access_token=github_access_token,
         repo_url=repo_url,
         title="Release {version}".format(version=new_version),
-        body=checklist,
+        body=create_release_notes(old_version, with_checkboxes=True),
         head="release-candidate",
         base="release",
     )

--- a/release.py
+++ b/release.py
@@ -15,9 +15,11 @@ import os
 from pkg_resources import parse_version
 
 from exception import ReleaseException
+from github import create_pr
 
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+GIT_RELEASE_NOTES_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/git-release-notes")
 
 
 class DependencyException(Exception):
@@ -58,14 +60,12 @@ def validate_dependencies():
     """Error if a dependency is missing or invalid"""
     print("Validating dependencies...")
 
-    if not dependency_exists("hub"):
-        raise DependencyException('Please install hub https://hub.github.com/')
     if not dependency_exists("git"):
         raise DependencyException('Please install git https://git-scm.com/downloads')
-    if not dependency_exists("git-release-notes"):
-        raise DependencyException('Please install git-release-notes https://www.npmjs.com/package/git-release-notes')
     if not dependency_exists("node"):
         raise DependencyException('Please install node.js https://nodejs.org/')
+    if not dependency_exists(GIT_RELEASE_NOTES_PATH):
+        raise DependencyException("Please run 'npm install' first")
 
     version = check_output(["node", "--version"]).decode()
     major_version = int(re.match(r'^v(\d+)\.', version).group(1))
@@ -164,7 +164,7 @@ def create_release_notes(old_version, with_checkboxes):
         filename = "release_notes_rst.ejs"
 
     return "{}\n".format(check_output([
-        "git-release-notes",
+        GIT_RELEASE_NOTES_PATH,
         "v{}..master".format(old_version),
         os.path.join(SCRIPT_DIR, "util", filename),
     ]).decode().strip())
@@ -214,22 +214,41 @@ def build_release():
     check_call(["git", "push", "--force", "-q", "origin", "release-candidate:release-candidate"])
 
 
-def generate_release_pr(old_version, new_version):
-    """Make a release pull request for the deployed release-candidate branch"""
+def generate_release_pr(github_access_token, repo_url, old_version, new_version):
+    """
+    Make a release pull request for the deployed release-candidate branch
+
+    Args:
+        github_access_token (str): The github access token
+        repo_url (str): URL for the repo
+        old_version (str): The previous release version
+        new_version (str): The version of the new release
+    """
     print("Generating PR...")
 
-    checklist_file = "release-notes-checklist"
-    with open(checklist_file, "w") as f:
-        f.write("Release {}\n".format(new_version))
-        f.write("\n")
+    checklist_header = "Release {version}\n\n".format(version=new_version)
+    checklist_body = create_release_notes(old_version, with_checkboxes=True)
+    checklist = "{}{}".format(checklist_header, checklist_body)
 
-        f.write(create_release_notes(old_version, with_checkboxes=True))
+    create_pr(
+        github_access_token=github_access_token,
+        repo_url=repo_url,
+        title="Release {version}".format(version=new_version),
+        body=checklist,
+        head="release-candidate",
+        base="release",
+    )
 
-    check_call(["hub", "pull-request", "-b", "release", "-h", "release-candidate", "-F", checklist_file])
 
+def release(github_access_token, repo_url, new_version):
+    """
+    Run a release
 
-def release(repo_url, new_version):
-    """Run a release"""
+    Args:
+        github_access_token (str): The github access token
+        repo_url (str): URL for a repo
+        new_version (str): The version of the new release
+    """
 
     validate_dependencies()
 
@@ -244,7 +263,7 @@ def release(repo_url, new_version):
         verify_new_commits(old_version)
         update_release_notes(old_version, new_version)
         build_release()
-        generate_release_pr(old_version, new_version)
+        generate_release_pr(github_access_token, repo_url, old_version, new_version)
 
     print("version {old_version} has been updated to {new_version}".format(
         old_version=old_version,
@@ -258,12 +277,16 @@ def main():
     """
     Create a new release
     """
+    try:
+        github_access_token = os.environ['GITHUB_ACCESS_TOKEN']
+    except KeyError:
+        raise Exception("Missing GITHUB_ACCESS_TOKEN")
     parser = argparse.ArgumentParser()
     parser.add_argument("repo_url")
     parser.add_argument("version")
     args = parser.parse_args()
 
-    release(repo_url=args.repo_url, new_version=args.version)
+    release(github_access_token=github_access_token, repo_url=args.repo_url, new_version=args.version)
 
 
 if __name__ == "__main__":

--- a/release_test.py
+++ b/release_test.py
@@ -15,6 +15,7 @@ from release import (
     create_release_notes,
     dependency_exists,
     DependencyException,
+    generate_release_pr,
     GIT_RELEASE_NOTES_PATH,
     init_working_dir,
     SCRIPT_DIR,
@@ -357,3 +358,31 @@ def test_verify_new_commits(test_repo):
     make_empty_commit("User 1", "  Release 0.0.1  ")
     # No exception
     verify_new_commits("0.0.1")
+
+
+def test_generate_release_pr(test_repo):
+    """generate_release_pr should create a PR"""
+    access_token = 'access_token'
+    repo_url = 'http://repo.url.fake/'
+    old_version = '1.2.3'
+    new_version = '4.5.6'
+    body = 'body'
+
+    with patch('release.create_pr', autospec=True) as create_pr_mock, patch(
+        'release.create_release_notes', autospec=True, return_value=body
+    ) as create_release_notes_mock:
+        generate_release_pr(
+            access_token,
+            repo_url,
+            old_version,
+            new_version,
+        )
+    create_pr_mock.assert_called_once_with(
+        github_access_token=access_token,
+        repo_url=repo_url,
+        title="Release {}".format(new_version),
+        body=body,
+        head="release-candidate",
+        base="release",
+    )
+    create_release_notes_mock.assert_called_once_with(old_version, with_checkboxes=True)

--- a/release_test.py
+++ b/release_test.py
@@ -15,7 +15,9 @@ from release import (
     create_release_notes,
     dependency_exists,
     DependencyException,
+    GIT_RELEASE_NOTES_PATH,
     init_working_dir,
+    SCRIPT_DIR,
     update_release_notes,
     UpdateVersionException,
     update_version,
@@ -23,9 +25,6 @@ from release import (
     validate_dependencies,
     verify_new_commits,
 )
-
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 # pylint: disable=redefined-outer-name, unused-argument
@@ -168,7 +167,7 @@ def test_validate_dependencies():
     """validate_dependencies should raise an exception if a dependency is missing or invalid"""
     with patch('release.dependency_exists', return_value=True) as dependency_exists_stub:
         validate_dependencies()
-    for dependency in ('node', 'hub', 'git', 'git-release-notes'):
+    for dependency in ('node', 'git', GIT_RELEASE_NOTES_PATH):
         dependency_exists_stub.assert_any_call(dependency)
 
         with patch(

--- a/repo_info.py
+++ b/repo_info.py
@@ -1,0 +1,10 @@
+"""Information about repositories"""
+from collections import namedtuple
+
+RepoInfo = namedtuple('RepoInfo', [
+    'name',
+    'repo_url',
+    'rc_hash_url',
+    'prod_hash_url',
+    'channel_id',
+])


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #93 

#### What's this PR do?
 - Removes hub as a dependency and uses the github access token with the pull request API to create pull requests instead
 - Adds `package.json` to allow heroku to install git-release-notes

#### How should this be manually tested?
Start a release using `bot_local.py`
