### PR TITLE
Use authenticated github API requests

### DIFF
--- a/github_test.py
+++ b/github_test.py
@@ -9,6 +9,8 @@ from bot import SCRIPT_DIR
 from github import (
     create_pr,
     calculate_karma,
+    get_org_and_repo,
+    github_auth_headers,
     needs_review,
     KARMA_QUERY,
     NEEDS_REVIEW_QUERY,
@@ -109,3 +111,20 @@ def test_create_pr():
             'base': base,
         })
     )
+
+
+def test_github_auth_headers():
+    """github_auth_headers should have appropriate headers for autentication"""
+    github_access_token = 'access'
+    assert github_auth_headers(github_access_token) == {
+        "Authorization": "Bearer {}".format(github_access_token),
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+
+def test_get_org_and_repo():
+    """get_org_and_repo should get the GitHub organization and repo from the directory"""
+    # I would be fine with testing this on cwd but Travis has a really old version of git that doesn't support
+    # get-url
+    for git_url in ["git@github.com:mitodl/release-script.git", "https://github.com/mitodl/release-script.git"]:
+        assert get_org_and_repo(git_url) == ("mitodl", "release-script")

--- a/wait_for_checked.py
+++ b/wait_for_checked.py
@@ -2,12 +2,18 @@
 """Wait for all checkboxes to get checked off"""
 import argparse
 import asyncio
+import os
 
 from lib import wait_for_checkboxes
 
 
 def main():
     """Wait for all checkboxes to get checked off"""
+    try:
+        github_access_token = os.environ['GITHUB_ACCESS_TOKEN']
+    except KeyError:
+        raise Exception("Missing GITHUB_ACCESS_TOKEN")
+
     parser = argparse.ArgumentParser()
     parser.add_argument("repo")
     parser.add_argument("--org", default="mitodl")
@@ -17,7 +23,7 @@ def main():
         raise Exception("repo is just the repo name, not a URL or directory (ie 'micromasters')")
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(wait_for_checkboxes(args.org, args.repo))
+    loop.run_until_complete(wait_for_checkboxes(github_access_token, args.org, args.repo))
     loop.close()
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #99 

#### What's this PR do?
Replaces unauthenticated github API request for the requests information with an authenticated request which has a much higher limit

#### How should this be manually tested?
Do a release
