### PR TITLE
Added version check for doof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ htmlcov/
 *.pyc
 package-lock.json
 node_modules/
+.envrc

--- a/version.py
+++ b/version.py
@@ -1,0 +1,12 @@
+"""
+Checks the deployed version of the app
+"""
+from subprocess import check_output
+
+from release import init_working_dir
+
+
+def get_version_tag(github_access_token, repo_url, commit_hash):
+    """Determines the version tag (or None) of the given commit hash"""
+    with init_working_dir(github_access_token, repo_url):
+        return check_output(["git", "tag", "-l", "--points-at", commit_hash]).decode().strip()


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds a version check command

#### How should this be manually tested?
`./bot_local.py mit-open-eng version` should print out the production version

#### Any background context you want to provide?
This depends on git tags, so the only environment we can check a version for is production.