### PR TITLE
Handle empty release notes

### DIFF
--- a/release.py
+++ b/release.py
@@ -161,12 +161,37 @@ def update_version(new_version):
     return old_version
 
 
+def any_new_commits(version):
+    """
+    Return true if there are any new commits since a release
+
+    Args:
+        version (str): A version string
+
+    Returns:
+        bool: True if there are new commits
+    """
+    return int(check_output(["git", "rev-list", "--count", "v{}..master".format(version)])) != 0
+
+
 def create_release_notes(old_version, with_checkboxes):
-    """Returns the release note text for the commits made for this version"""
+    """
+    Returns the release note text for the commits made for this version
+
+    Args:
+        old_version (str): The starting version of the range of commits
+        with_checkboxes (bool): If true, create the release notes with spaces for checkboxes
+
+    Returns:
+        str: The release notes
+    """
     if with_checkboxes:
         filename = "release_notes.ejs"
     else:
         filename = "release_notes_rst.ejs"
+
+    if not any_new_commits(old_version):
+        return "No new commits"
 
     return "{}\n".format(check_output([
         GIT_RELEASE_NOTES_PATH,
@@ -177,7 +202,7 @@ def create_release_notes(old_version, with_checkboxes):
 
 def verify_new_commits(old_version):
     """Check if there are new commits to release"""
-    if int(check_output(["git", "rev-list", "--count", "v{}..master".format(old_version)])) == 0:
+    if not any_new_commits(old_version):
         raise ReleaseException("No new commits to put in release")
 
 

--- a/release_test.py
+++ b/release_test.py
@@ -319,6 +319,16 @@ def test_create_release_notes(test_repo, with_checkboxes):
         ])
 
 
+@pytest.mark.parametrize("with_checkboxes", [True, False])
+def test_create_release_notes_empty(test_repo, with_checkboxes):
+    """create_release_notes should return a string saying there are no new commits"""
+    make_empty_commit("initial", "initial commit")
+    check_call(["git", "tag", "v0.0.1"])
+
+    notes = create_release_notes("0.0.1", with_checkboxes=with_checkboxes)
+    assert notes == "No new commits"
+
+
 def test_update_release_notes(test_repo):
     """update_release_notes should update the existing release notes and add new notes for the new commits"""
     check_call(["git", "checkout", "master"])


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #105

#### What's this PR do?
Fixes bug in handling release note creation when there are no commits

#### How should this be manually tested?
Run `@doof release notes` for a repo which just had a release finished
