### PR TITLE
Increase number of repositories to include

### DIFF
--- a/github.py
+++ b/github.py
@@ -12,7 +12,7 @@ KARMA_QUERY = """
 query {
 
   organization(login:"mitodl") {
-    repositories(first: 10, orderBy: {
+    repositories(first: 100, orderBy: {
       field: PUSHED_AT,
       direction: DESC
     }) {
@@ -43,7 +43,7 @@ query {
 NEEDS_REVIEW_QUERY = """
 query {
   organization(login:"mitodl") {
-    repositories(first: 10, orderBy: {
+    repositories(first: 100, orderBy: {
       field: PUSHED_AT,
       direction: DESC
     }) {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Increases the number of repositories to search through to 100. This list is ordered by most recently pushed commit, but we have more than 10 repositories which fix that criteria

#### How should this be manually tested?
Run `@doof what needs review` and `@doof karma 2018-01-01`. Both commands should produce output
