### PR TITLE
Name heroku dyno web to allow HTTP traffic

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-bot: python3 bot.py
+web: python3 bot.py


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #126 

#### What's this PR do?
Heroku only allows web traffic to go to dynos named `web`. This fixes the `Procfile` accordingly

#### How should this be manually tested?
N/A, there's no way to test this before merging it
