### PR TITLE
Use PORT from heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,6 +19,15 @@
     },
     "GITHUB_ACCESS_TOKEN": {
       "description": "Github access token"
+    },
+    "PORT": {
+      "description": "Heroku port number to use for web server"
+    },
+    "TIMEZONE": {
+      "description": "The time zone of the team"
+    },
+    "SLACK_WEBHOOK_TOKEN": {
+      "description": "The token used to authenticate requests to the webhook API"
     }
   },
   "keywords": [

--- a/bot.py
+++ b/bot.py
@@ -129,7 +129,8 @@ def in_script_dir(file_path):
 def get_envs():
     """Get required environment variables"""
     required_keys = (
-        'SLACK_ACCESS_TOKEN', 'BOT_ACCESS_TOKEN', 'GITHUB_ACCESS_TOKEN', 'SLACK_WEBHOOK_TOKEN', 'TIMEZONE',
+        'SLACK_ACCESS_TOKEN', 'BOT_ACCESS_TOKEN', 'GITHUB_ACCESS_TOKEN',
+        'SLACK_WEBHOOK_TOKEN', 'TIMEZONE', 'PORT',
     )
     env_dict = {key: os.environ.get(key, None) for key in required_keys}
     missing_env_keys = [k for k, v in env_dict.items() if v is None]
@@ -748,6 +749,10 @@ def main():
 
     channels_info = get_channels_info(envs['SLACK_ACCESS_TOKEN'])
     repos_info = load_repos_info(channels_info)
+    try:
+        port = int(envs['PORT'])
+    except ValueError:
+        raise Exception("PORT is invalid")
 
     resp = requests.post("https://slack.com/api/rtm.connect", data={
         "token": envs['BOT_ACCESS_TOKEN'],
@@ -763,7 +768,7 @@ def main():
                 github_access_token=envs['GITHUB_ACCESS_TOKEN'],
                 timezone=pytz.timezone(envs['TIMEZONE']),
             )
-            app = make_app(token=envs['SLACK_WEBHOOK_TOKEN'], bot=bot, repos_info=repos_info)
+            app = make_app(token=envs['SLACK_WEBHOOK_TOKEN'], bot=bot, repos_info=repos_info, port=port)
             try:
                 while True:
                     message = await websocket.recv()

--- a/bot.py
+++ b/bot.py
@@ -129,8 +129,12 @@ def in_script_dir(file_path):
 def get_envs():
     """Get required environment variables"""
     required_keys = (
-        'SLACK_ACCESS_TOKEN', 'BOT_ACCESS_TOKEN', 'GITHUB_ACCESS_TOKEN',
-        'SLACK_WEBHOOK_TOKEN', 'TIMEZONE', 'PORT',
+        'SLACK_ACCESS_TOKEN',
+        'BOT_ACCESS_TOKEN',
+        'GITHUB_ACCESS_TOKEN',
+        'SLACK_WEBHOOK_TOKEN',
+        'TIMEZONE',
+        'PORT',
     )
     env_dict = {key: os.environ.get(key, None) for key in required_keys}
     missing_env_keys = [k for k, v in env_dict.items() if v is None]

--- a/web.py
+++ b/web.py
@@ -35,7 +35,7 @@ class ButtonHandler(RequestHandler):
         self.finish("")
 
 
-def make_app(token, bot, repos_info, port=8999):
+def make_app(token, bot, repos_info, port):
     """Create the application handling the webhook requests"""
     app = Application([
         (r'/api/v0/buttons/', ButtonHandler, {'token': token, 'bot': bot, 'repos_info': repos_info}),


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #126 

#### What's this PR do?
Uses the correct port number so heroku knows about our web server

#### How should this be manually tested?
Set `PORT=8999` or any other port number, run `bot.py` and then run `curl -X POST --data "{}" http://localhost:8999/api/v0/buttons/`. You should see a 400 error with 'Missing argument payload'
