### PR TITLE
Fix typing indication

### DIFF
--- a/bot_local.py
+++ b/bot_local.py
@@ -21,6 +21,9 @@ class ConsoleBot(Bot):
         line = " ".join(word for word in [text, attachment_text, message_type] if word)
         print("\033[92m{}\033[0m".format(line))
 
+    async def typing(self, channel_id):
+        """Ignore typing messages"""
+
 
 def main():
     """Handle command line arguments and run a command"""
@@ -40,6 +43,7 @@ def main():
     repos_info = load_repos_info(channels_info)
 
     bot = Bot(
+        websocket=None,
         slack_access_token=envs['SLACK_ACCESS_TOKEN'],
         github_access_token=envs['GITHUB_ACCESS_TOKEN'],
         timezone=envs['TIMEZONE'],


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #122 

#### What's this PR do?
The typing indication looks to be only available via the websocket API, so this reverts that piece of #115 

#### How should this be manually tested?
Run doof locally and ask for something a little time consuming (for example who needs reviews). There should be a typing indication
