### PR TITLE
Fetch all tags on git fetch so we can error on duplicate tags

### DIFF
--- a/release.py
+++ b/release.py
@@ -54,7 +54,7 @@ def init_working_dir(github_access_token, repo_url):
             # from http://stackoverflow.com/questions/2411031/how-do-i-clone-into-a-non-empty-directory
             check_call(["git", "init"])
             check_call(["git", "remote", "add", "origin", url])
-            check_call(["git", "fetch"])
+            check_call(["git", "fetch", "--tags"])
             check_call(["git", "checkout", "-t", "origin/master"])
             yield directory
     finally:
@@ -171,7 +171,7 @@ def any_new_commits(version):
     Returns:
         bool: True if there are new commits
     """
-    return int(check_output(["git", "rev-list", "--count", "v{}..master".format(version)])) != 0
+    return int(check_output(["git", "rev-list", "--count", "v{}..master".format(version), "--"])) != 0
 
 
 def create_release_notes(old_version, with_checkboxes):

--- a/release_test.py
+++ b/release_test.py
@@ -247,7 +247,7 @@ def test_init_working_dir():
     assert [call[0][0] for call in calls] == [
         ['git', 'init'],
         ['git', 'remote', 'add', 'origin', url_with_access_token(access_token, repo_url)],
-        ['git', 'fetch'],
+        ['git', 'fetch', '--tags'],
         ['git', 'checkout', '-t', 'origin/master'],
     ]
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
If a tag already exists on a remote instance but is not available on master `git fetch` won't get it, so duplicate tags will not be detected. Running `git fetch --tags` instead should download all available tags which will cause `git tag` to error if it tries to create a duplicate tag

#### How should this be manually tested?
Create an orphaned tag on a release then run the release script for that version