### PR TITLE
Add command to upload to pypi

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     ./.tox/*
     *_test.py
     *_tests.py
+    /tmp/*
 
 [report]
 exclude_lines =

--- a/README.md
+++ b/README.md
@@ -112,7 +112,18 @@ To wait for successful deployment of micromasters to production:
     
 ## Releasing to PyPI 
 
-For python libraries and XBlocks, once the the release is finished, it needs to be uploaded to PyPI.
+For python libraries and XBlocks, once the the release is finished, it needs to be uploaded to PyPI. The easiest
+way to do this is through doof, but first you need to set these environment variables:
+
+- `PYPI_USERNAME`
+- `PYPI_PASSWORD`
+- `PYPITEST_USERNAME`
+- `PYPITEST_PASSWORD`
+
+To upload via Doof, run `@doof upload to pypitest 1.2.3` where `1.2.3` is an already released version. If that works
+run `@doof upload to pypy 1.2.3` to upload to the production package repository.
+
+### Manual PyPI release
 
 1. Get the PyPI credentials from DevOps.
 If you haven't already, you should set up a ``.pypirc`` file as described in 

--- a/bot.py
+++ b/bot.py
@@ -44,7 +44,6 @@ from lib import (
     parse_date,
     VERSION_RE,
     upload_to_pypi,
-    wait_for_checkboxes,
 )
 from repo_info import RepoInfo
 from wait_for_deploy import (

--- a/bot.py
+++ b/bot.py
@@ -43,6 +43,8 @@ from lib import (
     next_workday_at_10,
     parse_date,
     VERSION_RE,
+    upload_to_pypi,
+    wait_for_checkboxes,
 )
 from repo_info import RepoInfo
 from wait_for_deploy import (
@@ -118,6 +120,8 @@ def load_repos_info(channel_lookup):
                 ),
                 channel_id=channel_lookup[repo_info['channel_name']],
                 project_type=repo_info['project_type'],
+                python2=repo_info['python2'],
+                python3=repo_info['python3'],
             ) for repo_info in repos_info['repos']
         ]
 
@@ -144,6 +148,10 @@ def get_envs():
         'SLACK_WEBHOOK_TOKEN',
         'TIMEZONE',
         'PORT',
+        'PYPI_USERNAME',
+        'PYPI_PASSWORD',
+        'PYPITEST_USERNAME',
+        'PYPITEST_PASSWORD',
     )
     env_dict = {key: os.environ.get(key, None) for key in required_keys}
     missing_env_keys = [k for k, v in env_dict.items() if v is None]
@@ -471,6 +479,45 @@ class Bot:
             ]
         )
 
+    async def upload_to_pypitest(self, command_args):
+        """
+        Upload package for version to pypitest server
+
+        Args:
+            command_args (CommandArgs): The arguments for this command
+        """
+        await self._upload_to_pypi(command_args=command_args, testing=True)
+
+    async def upload_to_pypi(self, command_args):
+        """
+        Upload package for version to pypi server
+
+        Args:
+            command_args (CommandArgs): The arguments for this command
+        """
+        await self._upload_to_pypi(command_args=command_args, testing=False)
+
+    async def _upload_to_pypi(self, *, command_args, testing):
+        """
+        Upload package for version to pypi server
+
+        Args:
+            command_args (CommandArgs): The arguments for this command
+        """
+        repo_info = command_args.repo_info
+        version = command_args.args[0]
+
+        with init_working_dir(self.github_access_token, repo_info.repo_url, branch="v{}".format(version)):
+            upload_to_pypi(repo_info=repo_info, testing=testing)
+
+        await self.say(
+            channel_id=command_args.channel_id,
+            text='Successfully uploaded {version} to {pypi_server}.'.format(
+                version=version,
+                pypi_server="pypitest" if testing else "pypi",
+            ),
+        )
+
     async def finish_release(self, command_args):
         """
         Merge the release candidate into the release branch, tag it, merge to master, and wait for deployment
@@ -715,6 +762,18 @@ class Bot:
                 parsers=[],
                 command_func=self.wait_for_checkboxes_command,
                 description='Wait for committers to check off their boxes',
+            ),
+            Command(
+                command='upload to pypi',
+                parsers=[Parser(func=get_version_number, description='new version number')],
+                command_func=self.upload_to_pypi,
+                description='Upload package to pypi',
+            ),
+            Command(
+                command='upload to pypitest',
+                parsers=[Parser(func=get_version_number, description='new version number')],
+                command_func=self.upload_to_pypitest,
+                description='Upload package to pypitest',
             ),
             Command(
                 command='hi',

--- a/bot_local.py
+++ b/bot_local.py
@@ -42,7 +42,7 @@ def main():
 
     repos_info = load_repos_info(channels_info)
 
-    bot = Bot(
+    bot = ConsoleBot(
         websocket=None,
         slack_access_token=envs['SLACK_ACCESS_TOKEN'],
         github_access_token=envs['GITHUB_ACCESS_TOKEN'],

--- a/bot_test.py
+++ b/bot_test.py
@@ -544,8 +544,8 @@ async def test_webhook_finish_release(doof, event_loop, mocker):
         },
     )
 
-    repo_url = TEST_REPOS_INFO[0].repo_url
-    hash_url = TEST_REPOS_INFO[0].prod_hash_url
+    repo_url = WEB_TEST_REPO_INFO.repo_url
+    hash_url = WEB_TEST_REPO_INFO.prod_hash_url
     org, repo = get_org_and_repo(repo_url)
     wait_for_deploy_sync_mock.assert_any_call(
         github_access_token=doof.github_access_token,

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,113 @@
+"""Fixtures for tests"""
+from contextlib import contextmanager
+import gzip
+import os
+from shutil import copyfileobj
+from tempfile import (
+    TemporaryFile,
+    TemporaryDirectory,
+)
+from subprocess import check_call
+
+import pytest
+
+from bot import (
+    LIBRARY_TYPE,
+    WEB_APPLICATION_TYPE,
+)
+from release import SCRIPT_DIR
+from repo_info import RepoInfo
+
+
+SETUP_PY = """
+from setuptools import setup, find_packages
+
+setup(
+    name='ccxcon',
+    version='0.2.0',
+    license='AGPLv3',
+    author='MIT ODL Engineering',
+    author_email='odl-engineering@mit.edu',
+    url='http://github.com/mitodl/ccxcon',
+    description="CCX Connector",
+    # long_description=README,
+    packages=find_packages(),
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Programming Language :: Python',
+    ],
+    include_package_data=True,
+    zip_safe=False,
+)
+"""
+
+
+@contextmanager
+def _make_temp_repo():
+    """
+    Create a temporary directory with the test repo, similar to init_working_dir
+    but without connecting to the internet
+    """
+    pwd = os.getcwd()
+
+    try:
+        with TemporaryDirectory() as directory:
+            os.chdir(directory)
+            check_call(["git", "init", "--quiet"])
+            with gzip.open(os.path.join(SCRIPT_DIR, "test-repo.gz"), "rb") as test_repo_file:
+                # Passing this handle directly to check_call(...) below doesn't work, the data remains
+                # compressed. Why read() decompresses the data but passing the file object doesn't:
+                # https://bugs.python.org/issue24358
+                with TemporaryFile("wb") as temp_file:
+                    copyfileobj(test_repo_file, temp_file)
+                    temp_file.seek(0)
+
+                    check_call(["git", "fast-import", "--quiet"], stdin=temp_file)
+            check_call(["git", "checkout", "--quiet", "master"])
+            yield
+    finally:
+        os.chdir(pwd)
+
+
+WEB_TEST_REPO_INFO = RepoInfo(
+    name='doof_repo',
+    repo_url='http://github.com/mitodl/doof.git',
+    prod_hash_url='http://doof.example.com/hash.txt',
+    rc_hash_url='http://doof-rc.example.com/hash.txt',
+    channel_id='doof',
+    project_type=WEB_APPLICATION_TYPE,
+    python2=False,
+    python3=True,
+)
+
+
+@pytest.fixture
+def test_repo():
+    """Initialize the testing repo from the gzipped file"""
+    with _make_temp_repo():
+        yield WEB_TEST_REPO_INFO
+
+
+LIBRARY_TEST_REPO_INFO = RepoInfo(
+    name='lib_repo',
+    repo_url='http://github.com/mitodl/doof-lib.git',
+    prod_hash_url=None,
+    rc_hash_url=None,
+    channel_id='doof-lib',
+    project_type=LIBRARY_TYPE,
+    python2=True,
+    python3=False,
+)
+
+
+@pytest.fixture
+def library_test_repo():
+    """Initialize the library test repo from the gzipped file"""
+    with _make_temp_repo():
+        with open("setup.py", "w") as f:
+            # Hacky way to convert a web application project to a library
+            f.write(SETUP_PY)
+
+        yield LIBRARY_TEST_REPO_INFO

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -4,10 +4,7 @@ from subprocess import check_call
 import pytest
 
 from release import VersionMismatchException
-from release_test import (  # pylint: disable=unused-import
-    make_empty_commit,
-    test_repo,
-)
+from release_test import make_empty_commit
 from finish_release import (
     check_release_tag,
 )

--- a/release.py
+++ b/release.py
@@ -44,8 +44,11 @@ def dependency_exists(command):
 
 
 @contextmanager
-def init_working_dir(github_access_token, repo_url):
+def init_working_dir(github_access_token, repo_url, *, branch=None):
     """Create a new directory with an empty git repo"""
+    if branch is None:
+        branch = 'master'
+
     pwd = os.getcwd()
     url = url_with_access_token(github_access_token, repo_url)
     try:
@@ -55,7 +58,7 @@ def init_working_dir(github_access_token, repo_url):
             check_call(["git", "init"])
             check_call(["git", "remote", "add", "origin", url])
             check_call(["git", "fetch", "--tags"])
-            check_call(["git", "checkout", "-t", "origin/master"])
+            check_call(["git", "checkout", branch])
             yield directory
     finally:
         os.chdir(pwd)

--- a/repo_info.py
+++ b/repo_info.py
@@ -8,4 +8,6 @@ RepoInfo = namedtuple('RepoInfo', [
     'prod_hash_url',
     'channel_id',
     'project_type',
+    'python2',
+    'python3',
 ])

--- a/repos_info.json
+++ b/repos_info.json
@@ -6,7 +6,9 @@
       "rc_hash_url": "https://micromasters-rc.odl.mit.edu/static/hash.txt",
       "prod_hash_url": "https://micromasters.mit.edu/static/hash.txt",
       "channel_name": "micromasters-eng",
-      "project_type": "web_application"
+      "project_type": "web_application",
+      "python2": false,
+      "python3": true
     },
     {
       "name": "bootcamp-ecommerce",
@@ -14,7 +16,9 @@
       "rc_hash_url": "https://bootcamp-ecommerce-rc.herokuapp.com/static/hash.txt",
       "prod_hash_url": "https://bootcamp-ecommerce.herokuapp.com/static/hash.txt",
       "channel_name": "bootcamp-eng",
-      "project_type": "web_application"
+      "project_type": "web_application",
+      "python2": false,
+      "python3": true
     },
     {
       "name": "open-discussions",
@@ -22,7 +26,9 @@
       "rc_hash_url": "https://odl-open-discussions-rc.herokuapp.com/static/hash.txt",
       "prod_hash_url": "https://odl-open-discussions.herokuapp.com/static/hash.txt",
       "channel_name": "mit-open-eng",
-      "project_type": "web_application"
+      "project_type": "web_application",
+      "python2": false,
+      "python3": true
     },
     {
       "name": "odl-video-service",
@@ -30,19 +36,25 @@
       "rc_hash_url": "https://video-rc.odl.mit.edu/static/hash.txt",
       "prod_hash_url": "https://video.odl.mit.edu/static/hash.txt",
       "channel_name": "odl-video-service-eng",
-      "project_type": "web_application"
+      "project_type": "web_application",
+      "python2": false,
+      "python3": true
     },
     {
       "name": "edx-sga",
       "repo_url": "https://github.com/mitodl/open-discussions.git",
       "channel_name": "edx-sga-doof",
-      "project_type": "library"
+      "project_type": "library",
+      "python2": true,
+      "python3": false
     },
     {
       "name": "rapid-response-xblock",
       "repo_url": "https://github.com/mitodl/rapid-response-xblock.git",
       "channel_name": "rapid-response-doof",
-      "project_type": "library"
+      "project_type": "library",
+      "python2": true,
+      "python3": false
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dateutil
 pytz
 websockets
 tornado
+virtualenv


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #142 

#### What's this PR do?
Adds a couple commands to upload a package to pypi

#### How should this be manually tested?
Upload a package to pypi. It might be best to use a version which is already on pypi and check the error message in the console to make sure that it's failing with a 400 error, saying that the package already exists. Or we can do an actual upload if there's the need.
