### PR TITLE
Insert release dates into RELEASE.rst

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -266,6 +266,7 @@ class Bot:
             github_access_token=self.github_access_token,
             repo_url=repo_url,
             version=version,
+            timezone=self.timezone
         )
         await self.say(
             channel_id=channel_id,
@@ -472,6 +473,7 @@ class Bot:
             github_access_token=self.github_access_token,
             repo_url=repo_url,
             version=version,
+            timezone=self.timezone
         )
 
         await self.say(

--- a/bot_test.py
+++ b/bot_test.py
@@ -7,7 +7,7 @@ import pytz
 
 from bot import (
     Bot,
-    FINISH_RELEASE_ID,
+    FINISH_RELEASE_ID
 )
 from conftest import (
     LIBRARY_TEST_REPO_INFO,
@@ -323,6 +323,7 @@ async def test_release_library(doof, library_test_repo, event_loop, mocker):
         github_access_token=GITHUB_ACCESS,
         repo_url=library_test_repo.repo_url,
         version=version,
+        timezone=doof.timezone
     )
     assert doof.said(
         "My evil scheme {version} for {project} has been merged!".format(
@@ -417,6 +418,7 @@ async def test_finish_release(doof, test_repo, event_loop, mocker):
         github_access_token=GITHUB_ACCESS,
         repo_url=test_repo.repo_url,
         version=version,
+        timezone=doof.timezone
     )
     assert doof.said('deploying to production...')
     wait_for_deploy_sync_mock.assert_called_once_with(
@@ -562,6 +564,7 @@ async def test_webhook_finish_release(doof, event_loop, mocker):
         github_access_token=doof.github_access_token,
         repo_url=repo_url,
         version=pr_body.version,
+        timezone=doof.timezone
     )
     assert doof.said("Merging...")
     assert not doof.said("Error")

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from tempfile import (
 from subprocess import check_call
 
 import pytest
+import pytz
 
 from bot import (
     LIBRARY_TYPE,
@@ -111,3 +112,9 @@ def library_test_repo():
             f.write(SETUP_PY)
 
         yield LIBRARY_TEST_REPO_INFO
+
+
+@pytest.fixture
+def timezone():
+    """ Return a timezone object """
+    yield pytz.timezone('America/New_York')

--- a/finish_release.py
+++ b/finish_release.py
@@ -2,13 +2,13 @@
 import argparse
 import os
 import re
-
-import pytz
 from datetime import datetime
 from subprocess import (
     check_call,
     check_output,
 )
+
+import pytz
 
 from release import (
     init_working_dir,
@@ -47,9 +47,12 @@ def tag_release(version):
 def set_release_date(version):
     """Sets the release date(s) in RELEASE.rst for any versions missing it"""
     print("Setting release date...")
-    check_call(["git", "fetch", "--tags"])
     release_filename = "RELEASE.rst"
-    date_format = '%Y-%m-%d'
+    if not os.path.isfile(release_filename):
+        return
+    date_format = "%Y-%m-%d"
+    check_call(["git", "fetch", "--tags"])
+
     with open(release_filename) as f:
         existing_note_lines = [line for line in f.readlines()]
 
@@ -61,11 +64,11 @@ def set_release_date(version):
                     if version_match:
                         version_line = version_match.group(0)
                         version_date = check_output(
-                            ["git",  "log",  "-1",  "--format=%ai", 'v{}'.format(version_line)]
-                        )
-                        localtime = datetime.strptime(version_date.decode('utf-8'), '%Y-%m-%d %H:%M:%S %z\n').\
+                            ["git", "log", "-1", "--format=%ai", "v{}".format(version_line)]
+                        ).rstrip()
+                        localtime = datetime.strptime(version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z").\
                             astimezone(pytz.timezone("America/New_York")).strftime(date_format)
-                        line = 'Version {} (released {})\n'.format(version_line, localtime)
+                        line = "Version {} (Released {})\n".format(version_line, localtime)
                 f.write(line)
     except:  # pylint:disable=bare-except
         check_call(["git", "checkout", "HEAD", "--", release_filename])

--- a/finish_release.py
+++ b/finish_release.py
@@ -8,8 +8,6 @@ from subprocess import (
     check_output,
 )
 
-import pytz
-
 from release import (
     init_working_dir,
     validate_dependencies,
@@ -44,35 +42,32 @@ def tag_release(version):
     check_call(['git', 'push', '--follow-tags'])
 
 
-def set_release_date(version):
+def set_release_date(version, timezone):
     """Sets the release date(s) in RELEASE.rst for any versions missing it"""
     print("Setting release date...")
     release_filename = "RELEASE.rst"
     if not os.path.isfile(release_filename):
         return
-    date_format = "%Y-%m-%d"
+    date_format = "%B %d, %Y"
     check_call(["git", "fetch", "--tags"])
 
     with open(release_filename) as f:
         existing_note_lines = [line for line in f.readlines()]
 
-    try:
-        with open(release_filename, "w") as f:
-            for line in existing_note_lines:
-                if line.startswith("Version ") and "Released" not in line:
-                    version_match = re.search(r"[0-9\.]+", line)
-                    if version_match:
-                        version_line = version_match.group(0)
-                        version_date = check_output(
-                            ["git", "log", "-1", "--format=%ai", "v{}".format(version_line)]
-                        ).rstrip()
-                        localtime = datetime.strptime(version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z").\
-                            astimezone(pytz.timezone("America/New_York")).strftime(date_format)
-                        line = "Version {} (Released {})\n".format(version_line, localtime)
-                f.write(line)
-    except:  # pylint:disable=bare-except
-        check_call(["git", "checkout", "HEAD", "--", release_filename])
-        raise
+    with open(release_filename, "w") as f:
+        for line in existing_note_lines:
+            if line.startswith("Version ") and "Released" not in line:
+                version_match = re.search(r"[0-9\.]+", line)
+                if version_match:
+                    version_line = version_match.group(0)
+                    version_date = check_output(
+                        ["git", "log", "-1", "--format=%ai", "v{}".format(version_line)]
+                    ).rstrip()
+                    localtime = datetime.strptime(version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z").\
+                        astimezone(timezone).strftime(date_format)
+                    line = "Version {} (Released {})\n".format(version_line, localtime)
+            f.write(line)
+
     check_call(["git", "commit", "-q", release_filename, "-m", "Release date for {}".format(version)])
     check_call(['git', 'push'])
 
@@ -86,7 +81,7 @@ def merge_release():
     check_call(['git', 'push'])
 
 
-def finish_release(*, github_access_token, repo_url, version):
+def finish_release(*, github_access_token, repo_url, version, timezone):
     """Merge release to master and deploy to production"""
 
     validate_dependencies()
@@ -95,7 +90,7 @@ def finish_release(*, github_access_token, repo_url, version):
         merge_release_candidate()
         tag_release(version)
         merge_release()
-        set_release_date(version)
+        set_release_date(version, timezone)
 
 
 def main():
@@ -116,6 +111,7 @@ def main():
         github_access_token=github_access_token,
         repo_url=args.repo_url,
         version=args.version,
+        timezone=args.timezone
     )
 
 

--- a/finish_release.py
+++ b/finish_release.py
@@ -1,6 +1,10 @@
 """Release script to finish the release"""
 import argparse
 import os
+import re
+
+import pytz
+from datetime import datetime
 from subprocess import (
     check_call,
     check_output,
@@ -40,6 +44,36 @@ def tag_release(version):
     check_call(['git', 'push', '--follow-tags'])
 
 
+def set_release_date(version):
+    """Sets the release date(s) in RELEASE.rst for any versions missing it"""
+    print("Setting release date...")
+    check_call(["git", "fetch", "--tags"])
+    release_filename = "RELEASE.rst"
+    date_format = '%Y-%m-%d'
+    with open(release_filename) as f:
+        existing_note_lines = [line for line in f.readlines()]
+
+    try:
+        with open(release_filename, "w") as f:
+            for line in existing_note_lines:
+                if line.startswith("Version ") and "Released" not in line:
+                    version_match = re.search(r"[0-9\.]+", line)
+                    if version_match:
+                        version_line = version_match.group(0)
+                        version_date = check_output(
+                            ["git",  "log",  "-1",  "--format=%ai", 'v{}'.format(version_line)]
+                        )
+                        localtime = datetime.strptime(version_date.decode('utf-8'), '%Y-%m-%d %H:%M:%S %z\n').\
+                            astimezone(pytz.timezone("America/New_York")).strftime(date_format)
+                        line = 'Version {} (released {})\n'.format(version_line, localtime)
+                f.write(line)
+    except:  # pylint:disable=bare-except
+        check_call(["git", "checkout", "HEAD", "--", release_filename])
+        raise
+    check_call(["git", "commit", "-q", release_filename, "-m", "Release date for {}".format(version)])
+    check_call(['git', 'push'])
+
+
 def merge_release():
     """Merge release to master"""
     print("Merge release to master")
@@ -58,6 +92,7 @@ def finish_release(*, github_access_token, repo_url, version):
         merge_release_candidate()
         tag_release(version)
         merge_release()
+        set_release_date(version)
 
 
 def main():

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -98,11 +98,9 @@ def test_set_release_date(test_repo, mocker):
     mocker.patch('finish_release.check_output', autospec=True, return_value=b"2018-07-23 12:00:00 +0000\n")
     make_empty_commit("initial", "initial commit")
     check_call(["git", "tag", "v0.1.0"])
-
     make_empty_commit("User 1", "Commit #1")
-    make_empty_commit("User 2", "Commit #2")
     create_release_notes("0.1.0", with_checkboxes=False)
-    make_empty_commit("User 2", "Commit #3")
+    make_empty_commit("User 2", "Commit #2")
     check_call(["git", "tag", "v0.2.0"])
     create_release_notes("0.2.0", with_checkboxes=False)
     set_release_date("0.2.0")

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -105,6 +105,36 @@ def test_set_release_date(test_repo, mocker):
     check_call(["git", "tag", "v0.2.0"])
     create_release_notes("0.2.0", with_checkboxes=False)
     set_release_date("0.2.0")
-    content = open("RELEASE.rst").read()
+    with open('RELEASE.rst') as release_file:
+        content = release_file.read()
     assert re.search(r"Version 0.1.0 \(Released 2018-07-23\)", content) is not None
     assert re.search(r"Version 0.2.0 \(Released 2018-07-23\)", content) is not None
+
+
+def test_set_release_date_no_file(test_repo, mocker):
+    """ set_release_date should exit immediately if no release file exists """
+    mock_check = mocker.patch('finish_release.check_call', autospec=True)
+    mock_output = mocker.patch('finish_release.check_output', autospec=True)
+    mocker.patch('finish_release.os.path.isfile', return_value=False)
+    make_empty_commit("initial", "initial commit")
+    set_release_date("0.1.0")
+    mock_check.assert_not_called()
+    mock_output.assert_not_called()
+
+
+def test_set_release_date_revert_file(test_repo, mocker):
+    """ set_release_date should revert the file if an exception occurs """
+    mocker.patch('finish_release.check_output', autospec=True, return_value=b"2018-07-23 12:00:00 +0000\n")
+    mocker.patch('finish_release.pytz.timezone', side_effect=Exception('fake'))
+    make_empty_commit("initial", "initial commit")
+    check_call(["git", "tag", "v0.1.0"])
+    make_empty_commit("User 1", "Commit #1")
+    create_release_notes("0.1.0", with_checkboxes=False)
+    with open('RELEASE.rst') as release_file:
+        original_content = release_file.read()
+    with pytest.raises(Exception):
+        set_release_date("0.2.0")
+    with open('RELEASE.rst') as release_file:
+        post_content = release_file.read()
+    assert original_content == post_content
+    assert re.search(r"Version 0.1.0 \(Released 2018-07-23\)", post_content) is None

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -13,7 +13,8 @@ from finish_release import (
     merge_release,
     merge_release_candidate,
     tag_release,
-    set_release_date)
+    set_release_date
+)
 
 
 # pylint: disable=unused-argument, redefined-outer-name

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -1,10 +1,11 @@
 """Tests for finish_release.py"""
+import re
 from contextlib import contextmanager
 from subprocess import check_call
 
 import pytest
 
-from release import VersionMismatchException
+from release import VersionMismatchException, create_release_notes
 from release_test import make_empty_commit
 from finish_release import (
     check_release_tag,
@@ -12,7 +13,7 @@ from finish_release import (
     merge_release,
     merge_release_candidate,
     tag_release,
-)
+    set_release_date)
 
 
 # pylint: disable=unused-argument, redefined-outer-name
@@ -76,6 +77,7 @@ def test_finish_release(mocker):
     merge_release_candidate_mock = mocker.patch('finish_release.merge_release_candidate', autospec=True)
     tag_release_mock = mocker.patch('finish_release.tag_release', autospec=True)
     merge_release_mock = mocker.patch('finish_release.merge_release', autospec=True)
+    set_version_date_mock = mocker.patch('finish_release.set_release_date', autospec=True)
 
     finish_release(
         github_access_token=token,
@@ -87,3 +89,23 @@ def test_finish_release(mocker):
     merge_release_candidate_mock.assert_called_once_with()
     tag_release_mock.assert_called_once_with(version)
     merge_release_mock.assert_called_once_with()
+    set_version_date_mock.assert_called_once_with(version)
+
+
+def test_set_release_date(test_repo, mocker):
+    """set_release_date should update release notes with dates"""
+    mocker.patch('finish_release.check_call', autospec=True)
+    mocker.patch('finish_release.check_output', autospec=True, return_value=b"2018-07-23 12:00:00 +0000\n")
+    make_empty_commit("initial", "initial commit")
+    check_call(["git", "tag", "v0.1.0"])
+
+    make_empty_commit("User 1", "Commit #1")
+    make_empty_commit("User 2", "Commit #2")
+    create_release_notes("0.1.0", with_checkboxes=False)
+    make_empty_commit("User 2", "Commit #3")
+    check_call(["git", "tag", "v0.2.0"])
+    create_release_notes("0.2.0", with_checkboxes=False)
+    set_release_date("0.2.0")
+    content = open("RELEASE.rst").read()
+    assert re.search(r"Version 0.1.0 \(Released 2018-07-23\)", content) is not None
+    assert re.search(r"Version 0.2.0 \(Released 2018-07-23\)", content) is not None

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -105,7 +105,7 @@ def test_set_release_date(test_repo, mocker):
     check_call(["git", "tag", "v0.2.0"])
     create_release_notes("0.2.0", with_checkboxes=False)
     set_release_date("0.2.0")
-    with open('RELEASE.rst') as release_file:
+    with open('RELEASE.rst', 'r') as release_file:
         content = release_file.read()
     assert re.search(r"Version 0.1.0 \(Released 2018-07-23\)", content) is not None
     assert re.search(r"Version 0.2.0 \(Released 2018-07-23\)", content) is not None
@@ -130,11 +130,9 @@ def test_set_release_date_revert_file(test_repo, mocker):
     check_call(["git", "tag", "v0.1.0"])
     make_empty_commit("User 1", "Commit #1")
     create_release_notes("0.1.0", with_checkboxes=False)
-    with open('RELEASE.rst') as release_file:
-        original_content = release_file.read()
+    mock_check = mocker.patch('finish_release.check_call', autospec=True)
     with pytest.raises(Exception):
         set_release_date("0.2.0")
-    with open('RELEASE.rst') as release_file:
-        post_content = release_file.read()
-    assert original_content == post_content
-    assert re.search(r"Version 0.1.0 \(Released 2018-07-23\)", post_content) is None
+    mock_check.assert_called_with(["git", "checkout", "HEAD", "--", 'RELEASE.rst'])
+    with open('RELEASE.rst', 'r') as infile:
+        assert re.search(r"Version 0.1.0 \(Released 2018-07-23\)", infile.read()) is None


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #158

#### What's this PR do?
Goes through RELEASE.rst line by line and appends a release date (based on date of version tag) to each line that is equal to "Version &lt;number&gt;", then commits and pushes the change.

#### How should this be manually tested?
- Partial test: In a python shell opened in a repo directory, copy over the `set_release_date` function and run it.
- Run a release

