### PR TITLE
Don't escape HTML entities in release notes

### DIFF
--- a/release_test.py
+++ b/release_test.py
@@ -300,6 +300,17 @@ def test_create_release_notes_empty(test_repo, with_checkboxes):
     assert notes == "No new commits"
 
 
+@pytest.mark.parametrize("with_checkboxes", [True, False])
+def test_create_release_notes_amp(test_repo, with_checkboxes):
+    """create_release_notes should not escape html entities"""
+    make_empty_commit("initial", "initial commit")
+    check_call(["git", "tag", "v0.0.1"])
+    make_empty_commit("User 1", "Commit & ' \"")
+
+    notes = create_release_notes("0.0.1", with_checkboxes=with_checkboxes)
+    assert "Commit & \' \"" in notes
+
+
 def test_update_release_notes(test_repo):
     """update_release_notes should update the existing release notes and add new notes for the new commits"""
     check_call(["git", "checkout", "master"])

--- a/util/release_notes.ejs
+++ b/util/release_notes.ejs
@@ -8,10 +8,10 @@ commits.forEach(function (commit) {
 })
 
 Object.keys(by_author).forEach(function (author) {
-  %>## <%= author %>
+  %>## <%- author %>
 <%
   by_author[author].forEach(function (commit) {
-    %>  - [ ] <%= commit.title %> ([<%= commit.sha1.substring(0,8) %>](../commit/<%= commit.sha1 %>))
+    %>  - [ ] <%- commit.title %> ([<%- commit.sha1.substring(0,8) %>](../commit/<%- commit.sha1 %>))
 <%
   });
   %>

--- a/util/release_notes_rst.ejs
+++ b/util/release_notes_rst.ejs
@@ -1,2 +1,2 @@
-<% commits.forEach(function (commit) { %>- <%= commit.title %>
+<% commits.forEach(function (commit) { %>- <%- commit.title %>
 <% }) %>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #160 

#### What's this PR do?
Switches to unescaped syntax in release note templates

#### How should this be manually tested?
Not sure this needs one, maybe just wait for a release with an ampersand
