### PR TITLE
Use today's date for newly finished releases

### DIFF
--- a/finish_release.py
+++ b/finish_release.py
@@ -61,11 +61,14 @@ def set_release_date(version, timezone):
                 version_match = re.search(r"[0-9\.]+", line)
                 if version_match:
                     version_line = version_match.group(0)
-                    version_date = check_output(
-                        ["git", "log", "-1", "--format=%ai", "v{}".format(version_line)]
-                    ).rstrip()
-                    localtime = datetime.strptime(version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z").\
-                        astimezone(timezone).strftime(date_format)
+                    if version_line == version:
+                        localtime = datetime.now().strftime(date_format)
+                    else:
+                        version_date = check_output(
+                            ["git", "log", "-1", "--format=%ai", "v{}".format(version_line)]
+                        ).rstrip()
+                        localtime = datetime.strptime(version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z").\
+                            astimezone(timezone).strftime(date_format)
                     line = "Version {} (Released {})\n".format(version_line, localtime)
             f.write(line)
 

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -1,4 +1,5 @@
 """Tests for finish_release.py"""
+from datetime import datetime
 import re
 from contextlib import contextmanager
 from subprocess import check_call
@@ -97,7 +98,7 @@ def test_finish_release(mocker, timezone):
 def test_set_release_date(test_repo, timezone, mocker):
     """set_release_date should update release notes with dates"""
     mocker.patch('finish_release.check_call', autospec=True)
-    mocker.patch('finish_release.check_output', autospec=True, return_value=b"2018-07-23 12:00:00 +0000\n")
+    mocker.patch('finish_release.check_output', autospec=True, return_value=b"2018-04-27 12:00:00 +0000\n")
     make_empty_commit("initial", "initial commit")
     check_call(["git", "tag", "v0.1.0"])
     make_empty_commit("User 1", "Commit #1")
@@ -108,8 +109,9 @@ def test_set_release_date(test_repo, timezone, mocker):
     set_release_date("0.2.0", timezone)
     with open('RELEASE.rst', 'r') as release_file:
         content = release_file.read()
-    assert re.search(r"Version 0.1.0 \(Released July 23, 2018\)", content) is not None
-    assert re.search(r"Version 0.2.0 \(Released July 23, 2018\)", content) is not None
+    assert re.search(r"Version 0.1.0 \(Released April 27, 2018\)", content) is not None
+    today = datetime.now().strftime("%B %d, %Y")
+    assert f"Version 0.2.0 (Released {today})" in content
 
 
 def test_set_release_date_no_file(test_repo, timezone, mocker):


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes the finish release process. It's looking for a tagged version to get the date but after the change in #162 it isn't tagged yet. Instead this checks that the version matches and uses today's date

#### How should this be manually tested?
Do a release
