### PR TITLE
Ping slack every 30 seconds, or else quit so heroku can restart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+sudo: required  # for python 3.7, may not be needed in future
+dist: xenial  # for python 3.7
 python:
-  - "3.6"
+  - "3.7"
 node_js:
   - "6.2"
 install:

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Git is available as a precompiled binary as well as from Homebrew on OSX:
 
     brew install git
 
-#### [Python 3.6+ - https://www.python.org/downloads/](https://www.python.org/downloads/)
+#### [Python 3.7+ - https://www.python.org/downloads/](https://www.python.org/downloads/)
 
-Python 3.6+ is required. (Python 3.5 might work, earlier versions will be missing async functionality.)
+Python 3.7+ is required.
 
 #### Python libraries
 

--- a/bot_test.py
+++ b/bot_test.py
@@ -620,7 +620,7 @@ async def test_uptime(doof, event_loop, mocker, test_repo):
     assert doof.said("Awake for 2 minutes.")
 
 
-async def test_reset(doof, event_loop, mocker, test_repo):
+async def test_reset(doof, event_loop, test_repo):
     """Reset should cause a reset"""
     with pytest.raises(ResetException):
         await doof.run_command(

--- a/bot_test.py
+++ b/bot_test.py
@@ -17,7 +17,10 @@ from constants import (
     TRAVIS_FAILURE,
     TRAVIS_SUCCESS,
 )
-from exception import ReleaseException
+from exception import (
+    ReleaseException,
+    ResetException,
+)
 from github import get_org_and_repo
 from lib import (
     format_user_id,
@@ -615,3 +618,14 @@ async def test_uptime(doof, event_loop, mocker, test_repo):
         loop=event_loop,
     )
     assert doof.said("Awake for 2 minutes.")
+
+
+async def test_reset(doof, event_loop, mocker, test_repo):
+    """Reset should cause a reset"""
+    with pytest.raises(ResetException):
+        await doof.run_command(
+            manager='mitodl_user',
+            channel_id=test_repo.channel_id,
+            words=['reset'],
+            loop=event_loop
+        )

--- a/exception.py
+++ b/exception.py
@@ -7,3 +7,7 @@ class InputException(Exception):
 
 class ReleaseException(Exception):
     """Exception raised for a command error due to some release status"""
+
+
+class ResetException(Exception):
+    """Exception meant to reset the process"""

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py37
 skipsdist = True
 
 [testenv]

--- a/web.py
+++ b/web.py
@@ -32,7 +32,6 @@ class ButtonHandler(RequestHandler):
             self.finish("")
             return
 
-        print("here")
         self.loop.create_task(
             self.bot.handle_webhook(webhook_dict=arguments, loop=self.loop)
         )

--- a/web.py
+++ b/web.py
@@ -32,6 +32,7 @@ class ButtonHandler(RequestHandler):
             self.finish("")
             return
 
+        print("here")
         self.loop.create_task(
             self.bot.handle_webhook(webhook_dict=arguments, loop=self.loop)
         )

--- a/web_test.py
+++ b/web_test.py
@@ -49,7 +49,12 @@ class FinishReleaseTests(AsyncHTTPTestCase):
         payload = {
             "token": self.token
         }
+
         with patch('bot.Bot.handle_webhook') as handle_webhook:
+            async def fake_webhook(*args, **kwargs):  # pylint: disable=unused-argument
+                pass
+            handle_webhook.return_value = fake_webhook()  # pylint: disable=assignment-from-no-return
+
             response = self.fetch('/api/v0/buttons/', method='POST', body=urllib.parse.urlencode({
                 "payload": json.dumps(payload),
             }))


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #67 

#### What's this PR do?
Adds a task to ping every 30 seconds, or else cancel the loop, causing the app to restart.

#### How should this be manually tested?
N/A, hopefully we won't notice any more unresponsive doof