### PR TITLE
Add redis, other minor tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.7
+WORKDIR /tmp
+
+RUN mkdir /src
+
+RUN apt-get update -y
+RUN apt-get install curl -y
+
+# pip
+RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
+
+RUN adduser --disabled-password --gecos "" mitodl
+
+
+# Install project packages
+COPY requirements.txt /tmp/requirements.txt
+COPY test_requirements.txt /tmp/test_requirements.txt
+RUN pip install -r requirements.txt -r test_requirements.txt
+
+USER mitodl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.4'
+services:
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash -c 'cd /src && python bot.py'
+    environment:
+      PORT: 2345
+      REDISCLOUD_URL: redis://redis:6379/4
+      DOOF_PREFIX: "[test]"
+    env_file: .envrc
+    links:
+      - redis
+    volumes:
+      - .:/src
+
+  redis:
+    image: redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytz
 websockets
 tornado
 virtualenv
+redis


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #179 

#### What's this PR do?
 - Adds redis library
 - Sets up docker for local development with redis, including a prefix URL useful for distinguishing heroku or local instances of Doof

#### How should this be manually tested?
Run `docker-compose up` then talk to doof directly on slack and say `@doof hi`. Two instances of doof should reply, one with a `[test]` prefix
