### PR TITLE
Adding mitxpro project to repos_info

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -34,6 +34,17 @@
       "announcements": false
     },
     {
+      "name": "mitxpro",
+      "repo_url": "https://github.com/mitodl/mitxpro.git",
+      "rc_hash_url": " https://xpro-rc.odl.mit.edu/static/hash.txt",
+      "prod_hash_url": " https://xpro.odl.mit.edu/static/hash.txt",
+      "channel_name": "mitxpro-eng",
+      "project_type": "web_application",
+      "python2": false,
+      "python3": true,
+      "announcements": false
+    },
+    {
       "name": "odl-video-service",
       "repo_url": "https://github.com/mitodl/odl-video-service.git",
       "rc_hash_url": "https://video-rc.odl.mit.edu/static/hash.txt",


### PR DESCRIPTION
#### What are the relevant tickets?
N/a

#### What's this PR do?
Adding mitxpro project to repos_info, specify the slack channel enabling deployments through doof.

#### How should this be manually tested?
Should be deployed and tested in the `mitxpro-eng` channel.

