### PR TITLE
Add message to indicate that doof is waiting on Travis

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -276,6 +276,10 @@ class Bot:
         )
 
         org, repo = get_org_and_repo(repo_url)
+        await self.say(
+            channel_id=channel_id,
+            text=f"My evil scheme {version} for {repo_info.name} has been released! Waiting for Travis..."
+        )
         status = await wait_for_travis(
             github_access_token=self.github_access_token,
             org=org,

--- a/bot_test.py
+++ b/bot_test.py
@@ -338,6 +338,9 @@ async def test_release_library(doof, library_test_repo, event_loop, mocker):
         timezone=doof.timezone
     )
     assert doof.said(
+        f"My evil scheme {pr.version} for {library_test_repo.name} has been released! Waiting for Travis..."
+    )
+    assert doof.said(
         "My evil scheme {version} for {project} has been merged!".format(
             version=pr.version,
             project=library_test_repo.name,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #152 

#### What's this PR do?
Adds a message saying that doof is waiting on Travis, to indicate to the user what is happening when releasing a library project

#### How should this be manually tested?
Merge and try a library release
