### PR TITLE
Add buttons to start a release after "release notes"

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,7 @@ import websockets
 
 from constants import (
     FINISH_RELEASE_ID,
+    NEW_RELEASE_ID,
     LIBRARY_TYPE,
     TRAVIS_SUCCESS,
     WEB_APPLICATION_TYPE,
@@ -32,6 +33,7 @@ from github import (
     needs_review,
 )
 from release import (
+    any_new_commits,
     create_release_notes,
     init_working_dir,
     release,
@@ -43,6 +45,7 @@ from lib import (
     format_user_id,
     load_repos_info,
     match_user,
+    next_versions,
     now_in_utc,
     next_workday_at_10,
     parse_date,
@@ -600,6 +603,32 @@ class Bot:
                 channel_id=repo_info.channel_id,
                 text=f"And also! There is a release already in progress: {release_pr.url}"
             )
+        elif any_new_commits(last_version):
+            new_minor, new_patch = next_versions(last_version)
+            await self.say(
+                channel_id=repo_info.channel_id,
+                text="Start a new release?",
+                attachments=[
+                    {
+                        "fallback": "New release",
+                        "callback_id": NEW_RELEASE_ID,
+                        "actions": [
+                            {
+                                "name": "minor_release",
+                                "text": new_minor,
+                                "value": new_minor,
+                                "type": "button",
+                            },
+                            {
+                                "name": "patch_release",
+                                "text": new_patch,
+                                "value": new_patch,
+                                "type": "button",
+                            }
+                        ]
+                    }
+                ]
+            )
 
     async def message_if_unchecked(self, repo_info):
         """
@@ -1009,6 +1038,35 @@ class Bot:
                 )
                 raise
 
+        elif callback_id == NEW_RELEASE_ID:
+            repo_info = self.get_repo_info(channel_id)
+            version = webhook_dict['actions'][0]['value']
+            await self.update_message(
+                channel_id=channel_id,
+                timestamp=timestamp,
+                text=original_text,
+                attachments=[{
+                    "title": f"Starting release {version}..."
+                }],
+            )
+            try:
+                await self.release_command(CommandArgs(
+                    channel_id=channel_id,
+                    repo_info=repo_info,
+                    args=[version],
+                    loop=loop,
+                    manager=user_id,
+                ))
+            except:
+                await self.update_message(
+                    channel_id=channel_id,
+                    timestamp=timestamp,
+                    text=original_text,
+                    attachments=[{
+                        "title": "Error starting release"
+                    }],
+                )
+                raise
         else:
             log.warning("Unknown callback id: %s", callback_id)
 

--- a/bot.py
+++ b/bot.py
@@ -589,6 +589,7 @@ class Bot:
             last_version = update_version("9.9.9")
 
             release_notes = create_release_notes(last_version, with_checkboxes=False)
+            has_new_commits = any_new_commits(last_version)
 
         await self.say_with_attachment(
             channel_id=repo_info.channel_id,
@@ -603,7 +604,7 @@ class Bot:
                 channel_id=repo_info.channel_id,
                 text=f"And also! There is a release already in progress: {release_pr.url}"
             )
-        elif any_new_commits(last_version):
+        elif has_new_commits:
             new_minor, new_patch = next_versions(last_version)
             await self.say(
                 channel_id=repo_info.channel_id,

--- a/bot_test.py
+++ b/bot_test.py
@@ -106,6 +106,7 @@ async def test_release_notes(doof, test_repo, event_loop, mocker):
     update_version_mock = mocker.patch('bot.update_version', autospec=True, return_value=old_version)
     notes = "some notes"
     create_release_notes_mock = mocker.patch('bot.create_release_notes', autospec=True, return_value=notes)
+    any_new_commits_mock = mocker.patch('bot.any_new_commits', autospec=True, return_value=True)
     org, repo = get_org_and_repo(test_repo.repo_url)
     release_pr = ReleasePR('version', f'https://github.com/{org}/{repo}/pulls/123456', 'body')
     get_release_pr_mock = mocker.patch('bot.get_release_pr', autospec=True, return_value=release_pr)
@@ -119,6 +120,7 @@ async def test_release_notes(doof, test_repo, event_loop, mocker):
 
     update_version_mock.assert_called_once_with("9.9.9")
     create_release_notes_mock.assert_called_once_with(old_version, with_checkboxes=False)
+    any_new_commits_mock.assert_called_once_with(old_version)
     get_release_pr_mock.assert_called_once_with(github_access_token=GITHUB_ACCESS, org=org, repo=repo)
 
     assert doof.said("Release notes since {}".format(old_version))

--- a/constants.py
+++ b/constants.py
@@ -9,6 +9,7 @@ NO_PR_BUILD = 'none'
 
 
 FINISH_RELEASE_ID = 'finish_release'
+NEW_RELEASE_ID = 'new_release'
 
 WEB_APPLICATION_TYPE = 'web_application'
 LIBRARY_TYPE = 'library'

--- a/lib.py
+++ b/lib.py
@@ -358,3 +358,19 @@ def load_repos_info(channel_lookup):
                 announcements=repo_info.get('announcements'),
             ) for repo_info in repos_info['repos']
         ]
+
+
+def next_versions(version):
+    """
+    Create the next minor and patch versions from existing version
+
+    Args:
+        version (str): A version string which is already validated
+
+    Returns:
+        (str, str): A new version with the minor version incremented, and the same with the patch version incremented
+    """
+    old_major, old_minor, patch_version = version.split(".")
+    new_minor = f"{old_major}.{int(old_minor) + 1}.0"
+    new_patch = f"{old_major}.{old_minor}.{int(patch_version) + 1}"
+    return new_minor, new_patch

--- a/lib_test.py
+++ b/lib_test.py
@@ -18,6 +18,7 @@ from lib import (
     load_repos_info,
     match_user,
     next_workday_at_10,
+    next_versions,
     parse_checkmarks,
     reformatted_full_name,
     ReleasePR,
@@ -323,3 +324,8 @@ def test_load_repos_info(mocker):
         ),
     ]
     assert json_load.call_count == 1
+
+
+def test_next_versions():
+    """next_versions should return a tuple of the updated minor and patch versions"""
+    assert next_versions("1.2.3") == ("1.3.0", "1.2.4")

--- a/release_test.py
+++ b/release_test.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from release import (
+    any_new_commits,
     create_release_notes,
     dependency_exists,
     DependencyException,
@@ -145,10 +146,6 @@ def test_dependency_exists():
     """dependency_exists should check that the command exists on the system"""
     assert dependency_exists("ls")
     assert not dependency_exists("xyzzy")
-
-
-def test_checkout():
-    """checkout should change the """
 
 
 def test_validate_dependencies():
@@ -309,6 +306,19 @@ def test_create_release_notes_amp(test_repo, with_checkboxes):
 
     notes = create_release_notes("0.0.1", with_checkboxes=with_checkboxes)
     assert "Commit & \' \"" in notes
+
+
+@pytest.mark.parametrize("has_commits", [True, False])
+def test_any_new_commits(test_repo, has_commits):
+    """any_new_commits should return a bool value saying whether there are new commits or not"""
+    make_empty_commit("initial", "initial commit")
+    check_call(["git", "tag", "v0.0.1"])
+
+    if has_commits:
+        make_empty_commit("User 1", "After 1")
+    check_call(["git", "tag", "v0.0.2"])
+
+    assert any_new_commits("0.0.1") is has_commits
 
 
 def test_update_release_notes(test_repo):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #133 

#### What's this PR do?
Adds buttons to start a minor or patch incremented release after running `@doof release notes`

#### How should this be manually tested?
Merge then try it out next release

