### PR TITLE
Replace subprocess and requests with asyncio variants

### DIFF
--- a/async_subprocess.py
+++ b/async_subprocess.py
@@ -1,0 +1,46 @@
+"""asyncio subprocess create_subprocess_exec"""
+import asyncio
+import subprocess
+
+
+async def check_call(args, *, env=None, shell=False):
+    """
+    Similar to subprocess.check_call but adapted for asyncio. Please add new arguments as needed.
+    """
+    returncode = await call(args, env=env, shell=shell)
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, args[0])
+
+
+async def check_output(args, *, env=None, shell=False):
+    """
+    Similar to subprocess.check_output but adapted for asyncio. Please add new arguments as needed.
+    """
+    create_func = asyncio.create_subprocess_shell if shell else asyncio.create_subprocess_exec
+    proc = await create_func(
+        *args,
+        stdin=None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    stdout_data, _ = await proc.communicate(input=None)
+    returncode = await proc.wait()
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, args[0])
+    return stdout_data
+
+
+async def call(args, *, env=None, shell=False):
+    """
+    Similar to subprocess.call but adapted for asyncio. Please add new arguments as needed.
+    """
+    create_func = asyncio.create_subprocess_shell if shell else asyncio.create_subprocess_exec
+    proc = await create_func(
+        *args,
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        env=env,
+    )
+    return await proc.wait()

--- a/bot_local.py
+++ b/bot_local.py
@@ -30,7 +30,7 @@ class ConsoleBot(Bot):
         """Ignore typing messages"""
 
 
-def main():
+async def async_main():
     """Handle command line arguments and run a command"""
     envs = get_envs()
 
@@ -39,7 +39,7 @@ def main():
 
     _, channel_name, *words = sys.argv
 
-    channels_info = get_channels_info(envs['SLACK_ACCESS_TOKEN'])
+    channels_info = await get_channels_info(envs['SLACK_ACCESS_TOKEN'])
     try:
         channel_id = channels_info[channel_name]
     except KeyError:
@@ -55,15 +55,20 @@ def main():
         repos_info=repos_info
     )
 
+    await bot.handle_message(
+        manager='mitodl_user',
+        channel_id=channel_id,
+        words=words,
+        loop=asyncio.get_event_loop(),
+    )
+
+
+def main():
+    """Main function"""
     loop = asyncio.get_event_loop()
     loop.run_until_complete(
         loop.create_task(
-            bot.handle_message(
-                manager='mitodl_user',
-                channel_id=channel_id,
-                words=words,
-                loop=loop,
-            )
+            async_main()
         )
     )
 

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ from bot import (
     LIBRARY_TYPE,
     WEB_APPLICATION_TYPE,
 )
+from lib import async_wrapper
 from release import SCRIPT_DIR
 from repo_info import RepoInfo
 
@@ -133,3 +134,17 @@ def library_test_repo():
 def timezone():
     """ Return a timezone object """
     yield pytz.timezone('America/New_York')
+
+
+@pytest.fixture
+def mocker(mocker):  # pylint: disable=redefined-outer-name
+    """Override to add async_patch"""
+
+    def async_patch(*args, **kwargs):
+        """Add a helper function to patch with an async wrapped function, which is returned"""
+        mocked = mocker.Mock(**kwargs)
+        mocker.patch(*args, new_callable=lambda: async_wrapper(mocked))
+        return mocked
+
+    mocker.async_patch = async_patch
+    return mocker

--- a/finish_release.py
+++ b/finish_release.py
@@ -1,13 +1,14 @@
 """Release script to finish the release"""
 import argparse
+import asyncio
 import os
 import re
 from datetime import datetime
-from subprocess import (
+
+from async_subprocess import (
     check_call,
     check_output,
 )
-
 from release import (
     init_working_dir,
     validate_dependencies,
@@ -15,19 +16,20 @@ from release import (
 )
 
 
-def merge_release_candidate():
+async def merge_release_candidate():
     """Merge release-candidate into release"""
     print("Merge release-candidate into release")
-    check_call(['git', 'checkout', 'release'])
-    check_call(['git', 'merge', 'release-candidate', '--no-edit'])
-    check_call(['git', 'push'])
+    await check_call(['git', 'checkout', 'release'])
+    await check_call(['git', 'merge', 'release-candidate', '--no-edit'])
+    await check_call(['git', 'push'])
 
 
-def check_release_tag(version):
+async def check_release_tag(version):
     """Check release version number"""
     print("Check release version number...")
-    check_call(['git', 'checkout', 'release-candidate'])
-    commit_name = check_output(['git', 'log', '-1', '--pretty=%B']).decode().strip()
+    await check_call(['git', 'checkout', 'release-candidate'])
+    log_output = await check_output(['git', 'log', '-1', '--pretty=%B'])
+    commit_name = log_output.decode().strip()
     if commit_name != "Release {}".format(version):
         raise VersionMismatchException("Commit name {commit_name} does not match tag number {version}".format(
             commit_name=commit_name,
@@ -35,22 +37,22 @@ def check_release_tag(version):
         ))
 
 
-def tag_release(version):
+async def tag_release(version):
     """Add git tag for release"""
     print("Tag release...")
-    check_call(['git', 'tag', '-a', '-m', "Release {}".format(version), "v{}".format(version)])
-    check_call(['git', 'push', '--follow-tags'])
+    await check_call(['git', 'tag', '-a', '-m', "Release {}".format(version), "v{}".format(version)])
+    await check_call(['git', 'push', '--follow-tags'])
 
 
-def set_release_date(version, timezone):
+async def set_release_date(version, timezone):
     """Sets the release date(s) in RELEASE.rst for any versions missing it"""
     print("Setting release date...")
     release_filename = "RELEASE.rst"
     if not os.path.isfile(release_filename):
         return
     date_format = "%B %d, %Y"
-    check_call(["git", "fetch", "--tags"])
-    check_call(['git', 'checkout', 'release-candidate'])
+    await check_call(["git", "fetch", "--tags"])
+    await check_call(['git', 'checkout', 'release-candidate'])
 
     with open(release_filename) as f:
         existing_note_lines = [line for line in f.readlines()]
@@ -64,36 +66,37 @@ def set_release_date(version, timezone):
                     if version_line == version:
                         localtime = datetime.now().strftime(date_format)
                     else:
-                        version_date = check_output(
+                        version_output = await check_output(
                             ["git", "log", "-1", "--format=%ai", "v{}".format(version_line)]
-                        ).rstrip()
+                        )
+                        version_date = version_output.rstrip()
                         localtime = datetime.strptime(version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z").\
                             astimezone(timezone).strftime(date_format)
                     line = "Version {} (Released {})\n".format(version_line, localtime)
             f.write(line)
 
-    check_call(["git", "commit", "-q", release_filename, "-m", "Release date for {}".format(version)])
+    await check_call(["git", "commit", "-q", release_filename, "-m", "Release date for {}".format(version)])
 
 
-def merge_release():
+async def merge_release():
     """Merge release to master"""
     print("Merge release to master")
-    check_call(['git', 'checkout', '-q', 'master'])
-    check_call(['git', 'pull'])
-    check_call(['git', 'merge', 'release', '--no-edit'])
-    check_call(['git', 'push'])
+    await check_call(['git', 'checkout', '-q', 'master'])
+    await check_call(['git', 'pull'])
+    await check_call(['git', 'merge', 'release', '--no-edit'])
+    await check_call(['git', 'push'])
 
 
-def finish_release(*, github_access_token, repo_url, version, timezone):
+async def finish_release(*, github_access_token, repo_url, version, timezone):
     """Merge release to master and deploy to production"""
 
-    validate_dependencies()
-    with init_working_dir(github_access_token, repo_url):
-        check_release_tag(version)
-        set_release_date(version, timezone)
-        merge_release_candidate()
-        tag_release(version)
-        merge_release()
+    await validate_dependencies()
+    async with init_working_dir(github_access_token, repo_url):
+        await check_release_tag(version)
+        await set_release_date(version, timezone)
+        await merge_release_candidate()
+        await tag_release(version)
+        await merge_release()
 
 
 def main():
@@ -110,12 +113,12 @@ def main():
     parser.add_argument("version")
     args = parser.parse_args()
 
-    finish_release(
+    asyncio.run(finish_release(
         github_access_token=github_access_token,
         repo_url=args.repo_url,
         version=args.version,
         timezone=args.timezone
-    )
+    ))
 
 
 if __name__ == "__main__":

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -1,11 +1,11 @@
 """Tests for finish_release.py"""
 from datetime import datetime
 import re
-from contextlib import contextmanager
-from subprocess import check_call
+from contextlib import asynccontextmanager
 
 import pytest
 
+from lib import check_call
 from release import VersionMismatchException, create_release_notes
 from release_test import make_empty_commit
 from finish_release import (
@@ -18,75 +18,80 @@ from finish_release import (
 )
 
 
+pytestmark = pytest.mark.asyncio
+
+
 # pylint: disable=unused-argument, redefined-outer-name
-def test_check_release_tag(test_repo):
+async def test_check_release_tag(test_repo):
     """check_release_tag should error if the most recent release commit doesn't match the version given"""
-    check_call(["git", "checkout", "-b", "release-candidate"])
+    await check_call(["git", "checkout", "-b", "release-candidate"])
 
     make_empty_commit("initial", "initial commit")
     make_empty_commit("User 1", "  Release 0.0.1  ")
     with pytest.raises(VersionMismatchException) as exception:
-        check_release_tag("0.0.2")
+        await check_release_tag("0.0.2")
     assert exception.value.args[0] == "Commit name Release 0.0.1 does not match tag number 0.0.2"
 
     # No exception here
-    check_release_tag("0.0.1")
+    await check_release_tag("0.0.1")
 
 
-def test_merge_release_candidate(mocker):
+async def test_merge_release_candidate(mocker):
     """merge_release should merge the release candidate into release and push it"""
-    patched_check_call = mocker.patch('finish_release.check_call', autospec=True)
-    merge_release_candidate()
+    patched_check_call = mocker.async_patch('finish_release.check_call')
+    await merge_release_candidate()
     patched_check_call.assert_any_call(['git', 'checkout', 'release'])
     patched_check_call.assert_any_call(['git', 'merge', 'release-candidate', '--no-edit'])
     patched_check_call.assert_any_call(['git', 'push'])
 
 
-def test_merge_release(mocker):
+async def test_merge_release(mocker):
     """merge_release should merge the release and push it to origin"""
-    patched_check_call = mocker.patch('finish_release.check_call', autospec=True)
-    merge_release()
+    patched_check_call = mocker.async_patch('finish_release.check_call')
+    await merge_release()
     patched_check_call.assert_any_call(['git', 'checkout', '-q', 'master'])
     patched_check_call.assert_any_call(['git', 'pull'])
     patched_check_call.assert_any_call(['git', 'merge', 'release', '--no-edit'])
     patched_check_call.assert_any_call(['git', 'push'])
 
 
-def test_tag_release(mocker):
+async def test_tag_release(mocker):
     """tag_release should tag the release"""
     version = 'version'
-    patched_check_call = mocker.patch('finish_release.check_call', autospec=True)
-    tag_release(version)
+    patched_check_call = mocker.async_patch('finish_release.check_call')
+    await tag_release(version)
     patched_check_call.assert_any_call(
         ['git', 'tag', '-a', '-m', "Release {}".format(version), "v{}".format(version)]
     )
     patched_check_call.assert_any_call(['git', 'push', '--follow-tags'])
 
 
-def test_finish_release(mocker, timezone):
+async def test_finish_release(mocker, timezone):
     """finish_release should tag, merge and push the release"""
     token = 'token'
     version = 'version'
     repo_url = 'repo_url'
 
-    @contextmanager
-    def fake_init(*args, **kwargs):  # pylint: disable=unused-argument
+    @asynccontextmanager
+    async def fake_init(*args, **kwargs):  # pylint: disable=unused-argument
         """Fake empty contextmanager"""
         yield
 
+    validate_dependencies_mock = mocker.async_patch('finish_release.validate_dependencies')
     init_working_dir_mock = mocker.patch('finish_release.init_working_dir', side_effect=fake_init)
-    check_release_mock = mocker.patch('finish_release.check_release_tag', autospec=True)
-    merge_release_candidate_mock = mocker.patch('finish_release.merge_release_candidate', autospec=True)
-    tag_release_mock = mocker.patch('finish_release.tag_release', autospec=True)
-    merge_release_mock = mocker.patch('finish_release.merge_release', autospec=True)
-    set_version_date_mock = mocker.patch('finish_release.set_release_date', autospec=True)
+    check_release_mock = mocker.async_patch('finish_release.check_release_tag')
+    merge_release_candidate_mock = mocker.async_patch('finish_release.merge_release_candidate')
+    tag_release_mock = mocker.async_patch('finish_release.tag_release')
+    merge_release_mock = mocker.async_patch('finish_release.merge_release')
+    set_version_date_mock = mocker.async_patch('finish_release.set_release_date')
 
-    finish_release(
+    await finish_release(
         github_access_token=token,
         repo_url=repo_url,
         version=version,
         timezone=timezone
     )
+    validate_dependencies_mock.assert_called_once_with()
     init_working_dir_mock.assert_called_once_with(token, repo_url)
     check_release_mock.assert_called_once_with(version)
     merge_release_candidate_mock.assert_called_once_with()
@@ -95,18 +100,18 @@ def test_finish_release(mocker, timezone):
     set_version_date_mock.assert_called_once_with(version, timezone)
 
 
-def test_set_release_date(test_repo, timezone, mocker):
+async def test_set_release_date(test_repo, timezone, mocker):
     """set_release_date should update release notes with dates"""
-    mocker.patch('finish_release.check_call', autospec=True)
-    mocker.patch('finish_release.check_output', autospec=True, return_value=b"2018-04-27 12:00:00 +0000\n")
+    mocker.async_patch('finish_release.check_call')
+    mocker.async_patch('finish_release.check_output', return_value=b"2018-04-27 12:00:00 +0000\n")
     make_empty_commit("initial", "initial commit")
-    check_call(["git", "tag", "v0.1.0"])
+    await check_call(["git", "tag", "v0.1.0"])
     make_empty_commit("User 1", "Commit #1")
-    create_release_notes("0.1.0", with_checkboxes=False)
+    await create_release_notes("0.1.0", with_checkboxes=False)
     make_empty_commit("User 2", "Commit #2")
-    check_call(["git", "tag", "v0.2.0"])
-    create_release_notes("0.2.0", with_checkboxes=False)
-    set_release_date("0.2.0", timezone)
+    await check_call(["git", "tag", "v0.2.0"])
+    await create_release_notes("0.2.0", with_checkboxes=False)
+    await set_release_date("0.2.0", timezone)
     with open('RELEASE.rst', 'r') as release_file:
         content = release_file.read()
     assert re.search(r"Version 0.1.0 \(Released April 27, 2018\)", content) is not None
@@ -114,12 +119,12 @@ def test_set_release_date(test_repo, timezone, mocker):
     assert f"Version 0.2.0 (Released {today})" in content
 
 
-def test_set_release_date_no_file(test_repo, timezone, mocker):
+async def test_set_release_date_no_file(test_repo, timezone, mocker):
     """ set_release_date should exit immediately if no release file exists """
     mock_check = mocker.patch('finish_release.check_call', autospec=True)
     mock_output = mocker.patch('finish_release.check_output', autospec=True)
     mocker.patch('finish_release.os.path.isfile', return_value=False)
     make_empty_commit("initial", "initial commit")
-    set_release_date("0.1.0", timezone)
+    await set_release_date("0.1.0", timezone)
     mock_check.assert_not_called()
     mock_output.assert_not_called()

--- a/github_test.py
+++ b/github_test.py
@@ -1,7 +1,6 @@
 """Tests for github functions"""
 import json
 import os
-from unittest.mock import patch
 
 from dateutil.parser import parse
 import pytest
@@ -25,79 +24,82 @@ from github import (
 )
 
 
-def test_karma():
+pytestmark = pytest.mark.asyncio
+
+
+async def test_karma(mocker):
     """Assert behavior of karma calculation"""
     with open(os.path.join(SCRIPT_DIR, "test_karma_response.json")) as f:
         payload = json.load(f)
     github_access_token = 'token'
 
-    with patch('github.run_query', autospec=True, return_value=payload) as patched:
-        assert calculate_karma(
-            github_access_token=github_access_token,
-            begin_date=parse("2017-11-09").date(),
-            end_date=parse("2017-11-09").date(),
-        ) == [
-            ('Tobias Macey', 1),
-        ]
+    patched = mocker.async_patch('github.run_query', return_value=payload)
+    assert await calculate_karma(
+        github_access_token=github_access_token,
+        begin_date=parse("2017-11-09").date(),
+        end_date=parse("2017-11-09").date(),
+    ) == [
+        ('Tobias Macey', 1),
+    ]
     patched.assert_called_once_with(
         github_access_token=github_access_token,
         query=KARMA_QUERY,
     )
 
 
-def test_needs_review():
+async def test_needs_review(mocker):
     """Assert behavior of needs review"""
     with open(os.path.join(SCRIPT_DIR, "test_needs_review_response.json")) as f:
         payload = json.load(f)
     github_access_token = 'token'
 
-    with patch('github.run_query', autospec=True, return_value=payload) as patched:
-        assert needs_review(github_access_token) == [
-            ('release-script', 'Add PR karma', 'https://github.com/mitodl/release-script/pull/88'),
-            ('release-script', 'Add codecov integration', 'https://github.com/mitodl/release-script/pull/85'),
-            (
-                'release-script',
-                'Add repo name to certain doof messages',
-                'https://github.com/mitodl/release-script/pull/83',
-            ),
-            (
-                'cookiecutter-djangoapp',
-                'Don\'t reference INSTALLED_APPS directly',
-                'https://github.com/mitodl/cookiecutter-djangoapp/pull/104',
-            ),
-            (
-                'cookiecutter-djangoapp',
-                'Refactor docker-compose setup',
-                'https://github.com/mitodl/cookiecutter-djangoapp/pull/101'
-            ),
-            (
-                'cookiecutter-djangoapp',
-                'Use application LOG_LEVEL environment variable for celery workers',
-                'https://github.com/mitodl/cookiecutter-djangoapp/pull/103'
-            ),
-            (
-                'micromasters',
-                'Log failed send_automatic_email and update_percolate_memberships',
-                'https://github.com/mitodl/micromasters/pull/3707'
-            ),
-            (
-                'open-discussions',
-                'split post display into two components',
-                'https://github.com/mitodl/open-discussions/pull/331'
-            ),
-            (
-                'edx-platform',
-                'Exposed option to manage static asset imports for studio import',
-                'https://github.com/mitodl/edx-platform/pull/41'
-            ),
-        ]
+    patched = mocker.async_patch('github.run_query', return_value=payload)
+    assert await needs_review(github_access_token) == [
+        ('release-script', 'Add PR karma', 'https://github.com/mitodl/release-script/pull/88'),
+        ('release-script', 'Add codecov integration', 'https://github.com/mitodl/release-script/pull/85'),
+        (
+            'release-script',
+            'Add repo name to certain doof messages',
+            'https://github.com/mitodl/release-script/pull/83',
+        ),
+        (
+            'cookiecutter-djangoapp',
+            'Don\'t reference INSTALLED_APPS directly',
+            'https://github.com/mitodl/cookiecutter-djangoapp/pull/104',
+        ),
+        (
+            'cookiecutter-djangoapp',
+            'Refactor docker-compose setup',
+            'https://github.com/mitodl/cookiecutter-djangoapp/pull/101'
+        ),
+        (
+            'cookiecutter-djangoapp',
+            'Use application LOG_LEVEL environment variable for celery workers',
+            'https://github.com/mitodl/cookiecutter-djangoapp/pull/103'
+        ),
+        (
+            'micromasters',
+            'Log failed send_automatic_email and update_percolate_memberships',
+            'https://github.com/mitodl/micromasters/pull/3707'
+        ),
+        (
+            'open-discussions',
+            'split post display into two components',
+            'https://github.com/mitodl/open-discussions/pull/331'
+        ),
+        (
+            'edx-platform',
+            'Exposed option to manage static asset imports for studio import',
+            'https://github.com/mitodl/edx-platform/pull/41'
+        ),
+    ]
     patched.assert_called_once_with(
         github_access_token=github_access_token,
         query=NEEDS_REVIEW_QUERY,
     )
 
 
-def test_create_pr():
+async def test_create_pr(mocker):
     """create_pr should create a pr or raise an exception if the attempt failed"""
     access_token = 'github_access_token'
     org = 'abc'
@@ -106,17 +108,18 @@ def test_create_pr():
     body = 'body'
     head = 'head'
     base = 'base'
-    with patch('requests.post', autospec=True) as patched:
-        create_pr(
-            github_access_token=access_token,
-            repo_url='https://github.com/{}/{}.git'.format(org, repo),
-            title=title,
-            body=body,
-            head=head,
-            base=base,
-        )
+    patched = mocker.async_patch('http3.AsyncClient.post')
+    await create_pr(
+        github_access_token=access_token,
+        repo_url='https://github.com/{}/{}.git'.format(org, repo),
+        title=title,
+        body=body,
+        head=head,
+        base=base,
+    )
     endpoint = 'https://api.github.com/repos/{}/{}/pulls'.format(org, repo)
     patched.assert_called_once_with(
+        mocker.ANY,
         endpoint,
         headers={
             "Authorization": "Bearer {}".format(access_token),
@@ -131,7 +134,7 @@ def test_create_pr():
     )
 
 
-def test_github_auth_headers():
+async def test_github_auth_headers():
     """github_auth_headers should have appropriate headers for autentication"""
     github_access_token = 'access'
     assert github_auth_headers(github_access_token) == {
@@ -140,7 +143,7 @@ def test_github_auth_headers():
     }
 
 
-def test_get_org_and_repo():
+async def test_get_org_and_repo():
     """get_org_and_repo should get the GitHub organization and repo from the directory"""
     # I would be fine with testing this on cwd but Travis has a really old version of git that doesn't support
     # get-url
@@ -169,7 +172,7 @@ NO_PR_BUILD_DATA = _load_status("no_pr_builds")
     [200, PENDING_DATA, TRAVIS_PENDING],
     [200, NO_PR_BUILD_DATA, NO_PR_BUILD],
 ])
-def test_get_status_of_pr(status_code, status_data, expected_status):
+async def test_get_status_of_pr(mocker, status_code, status_data, expected_status):
     """get_status_of_pr should get the status of a PR"""
 
     org = 'org'
@@ -177,16 +180,16 @@ def test_get_status_of_pr(status_code, status_data, expected_status):
     token = 'token'
     branch = 'branch'
 
-    with patch('requests.get', autospec=True) as patched:
-        resp = patched.return_value
-        resp.status_code = status_code
-        resp.json.return_value = status_data
-        assert get_status_of_pr(
-            github_access_token=token,
-            org=org,
-            repo=repo,
-            branch=branch,
-        ) == expected_status
+    patched = mocker.async_patch('http3.AsyncClient.get')
+    resp = patched.return_value
+    resp.status_code = status_code
+    resp.json.return_value = status_data
+    assert await get_status_of_pr(
+        github_access_token=token,
+        org=org,
+        repo=repo,
+        branch=branch,
+    ) == expected_status
 
     if status_code != 404:
         resp.raise_for_status.assert_called_once_with()
@@ -196,4 +199,4 @@ def test_get_status_of_pr(status_code, status_data, expected_status):
         repo=repo,
         ref=branch,
     )
-    patched.assert_called_once_with(endpoint, headers=github_auth_headers(token))
+    patched.assert_called_once_with(mocker.ANY, endpoint, headers=github_auth_headers(token))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+http3
 python-dateutil
 pytz
 websockets

--- a/slack.py
+++ b/slack.py
@@ -1,8 +1,8 @@
 """functions for interacting with slack"""
-import requests
+import http3
 
 
-def get_channels_info(slack_access_token):
+async def get_channels_info(slack_access_token):
     """
     Get channel information from slack
 
@@ -12,8 +12,9 @@ def get_channels_info(slack_access_token):
     Returns:
         dict: A map of channel names to channel ids
     """
+    client = http3.AsyncClient()
     # public channels
-    resp = requests.post("https://slack.com/api/channels.list", data={
+    resp = await client.post("https://slack.com/api/channels.list", data={
         "token": slack_access_token
     })
     resp.raise_for_status()
@@ -21,7 +22,7 @@ def get_channels_info(slack_access_token):
     channels_map = {channel['name']: channel['id'] for channel in channels}
 
     # private channels
-    resp = requests.post("https://slack.com/api/groups.list", data={
+    resp = await client.post("https://slack.com/api/groups.list", data={
         "token": slack_access_token
     })
     resp.raise_for_status()

--- a/slack_test.py
+++ b/slack_test.py
@@ -1,10 +1,16 @@
 """Tests for slack functions"""
+import pytest
+
+
 from slack import get_channels_info
 
 
-def test_get_channels_info(mocker):
+pytestmark = pytest.mark.asyncio
+
+
+async def test_get_channels_info(mocker):
     """get_channels_info should obtain information for all public and private channels that doof knows about"""
-    post_patch = mocker.patch('slack.requests.post')
+    post_patch = mocker.async_patch('slack.http3.AsyncClient.post')
     post_patch.return_value.json.side_effect = [
         {'channels': [{
             'name': 'a',
@@ -16,10 +22,10 @@ def test_get_channels_info(mocker):
         }]},
     ]
     token = 'token'
-    assert get_channels_info(token) == {
+    assert await get_channels_info(token) == {
         'a': 'public channel',
         'and a': 'private one',
     }
-    post_patch.assert_any_call("https://slack.com/api/channels.list", data={'token': token})
-    post_patch.assert_any_call("https://slack.com/api/groups.list", data={'token': token})
+    post_patch.assert_any_call(mocker.ANY, "https://slack.com/api/channels.list", data={'token': token})
+    post_patch.assert_any_call(mocker.ANY, "https://slack.com/api/groups.list", data={'token': token})
     assert post_patch.return_value.raise_for_status.call_count == 2

--- a/version.py
+++ b/version.py
@@ -1,12 +1,13 @@
 """
 Checks the deployed version of the app
 """
-from subprocess import check_output
+from async_subprocess import check_output
 
 from release import init_working_dir
 
 
-def get_version_tag(github_access_token, repo_url, commit_hash):
+async def get_version_tag(github_access_token, repo_url, commit_hash):
     """Determines the version tag (or None) of the given commit hash"""
-    with init_working_dir(github_access_token, repo_url):
-        return check_output(["git", "tag", "-l", "--points-at", commit_hash]).decode().strip()
+    async with init_working_dir(github_access_token, repo_url):
+        output = await check_output(["git", "tag", "-l", "--points-at", commit_hash])
+        return output.decode().strip()

--- a/wait_for_travis.py
+++ b/wait_for_travis.py
@@ -11,7 +11,7 @@ from github import get_status_of_pr
 
 async def wait_for_travis(*, github_access_token, org, repo, branch):
     """Wait for the PR status to become good"""
-    status = get_status_of_pr(github_access_token=github_access_token, org=org, repo=repo, branch=branch)
+    status = await get_status_of_pr(github_access_token=github_access_token, org=org, repo=repo, branch=branch)
 
     # If status is none we should try just once more. Maybe the PR is not yet created.
     if status in (TRAVIS_FAILURE, TRAVIS_SUCCESS):
@@ -21,7 +21,7 @@ async def wait_for_travis(*, github_access_token, org, repo, branch):
     await asyncio.sleep(30)
 
     while True:
-        status = get_status_of_pr(github_access_token=github_access_token, org=org, repo=repo, branch=branch)
+        status = await get_status_of_pr(github_access_token=github_access_token, org=org, repo=repo, branch=branch)
         if status in (TRAVIS_FAILURE, NO_PR_BUILD, TRAVIS_SUCCESS):
             return status
 

--- a/wait_for_travis_test.py
+++ b/wait_for_travis_test.py
@@ -24,14 +24,9 @@ pytestmark = pytest.mark.asyncio
 ])
 async def test_wait_for_travis(mocker, statuses, result):
     """wait_for_travis should check the github status API every 30 seconds"""
-    get_status_mock = mocker.patch('wait_for_travis.get_status_of_pr', autospec=True, side_effect=statuses)
-    sleep_sync_mock = mocker.Mock()
-
-    async def sleep_fake(*args, **kwargs):
-        """await cannot be used with mock objects"""
-        sleep_sync_mock(*args, **kwargs)
-
-    mocker.patch('asyncio.sleep', sleep_fake)
+    get_status_mock = mocker.async_patch('wait_for_travis.get_status_of_pr')
+    get_status_mock.side_effect = statuses
+    sleep_sync_mock = mocker.async_patch('asyncio.sleep')
 
     token = 'token'
     org = 'org'


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #193 
Fixes #194 

#### What's this PR do?
Replaces synchronous HTTP calls and subprocess calls with asyncio compatible variants. This should prevent doof from hanging while starting a release, or on a slow request from github. Doof will always be listening instead of only listening when there is nothing else going on.

#### How should this be manually tested?
Nothing should break