### PR TITLE
Add back requests library to fix Doof

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 http3
 python-dateutil
 pytz
+requests
 websockets
 tornado
 virtualenv


### PR DESCRIPTION
The previous PR #199 replaced most uses of `requests` with `aiohttp`, but some cannot be replaced because the requests are made outside the asyncio loop. This adds back the requests library to fix Doof.