### PR TITLE
Remove leading spaces from xpro URL

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -36,8 +36,8 @@
     {
       "name": "mitxpro",
       "repo_url": "https://github.com/mitodl/mitxpro.git",
-      "rc_hash_url": " https://xpro-rc.odl.mit.edu/static/hash.txt",
-      "prod_hash_url": " https://xpro.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://xpro-rc.odl.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://xpro.mit.edu/static/hash.txt",
       "channel_name": "mitxpro-eng",
       "project_type": "web_application",
       "python2": false,


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes leading spaces from the URLs used to poll xpro. It seems like `aiohttp` is more strict than `requests` was about spaces around the URL

#### How should this be manually tested?
N/A, we can do another xpro release after merge
