### PR TITLE
Add hotfix command to doof 

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -330,7 +330,7 @@ class Bot:
                 repo_url=repo_url,
                 new_version=version,
                 branch='release',
-                hash=command_args.args[1],
+                commit_hash=command_args.args[1],
             )
 
         else:
@@ -851,7 +851,7 @@ class Bot:
             ),
             Command(
                 command='hotfix',
-                parsers=[Parser(func=get_version_number, description='new version number')],
+                parsers=[Parser(func=get_version_number, description='commit hash to cherry-pick')],
                 command_func=self.hotfix_command,
                 description='Start a hotfix release',
                 supported_project_types=[WEB_APPLICATION_TYPE],

--- a/bot.py
+++ b/bot.py
@@ -369,7 +369,7 @@ class Bot:
             channel_id=channel_id,
             text="Release {version} for {project} was deployed! PR is up at {pr_url}."
             " These people have commits in this release: {authors}".format(
-                version=version,
+                version=hotfix_version if hotfix_version else passed_arg,
                 authors=", ".join(slack_usernames),
                 pr_url=pr.url,
                 project=repo_info.name,
@@ -1174,7 +1174,7 @@ def get_commit_hash(text):
     if hash_pattern.match(text):
         return text
     else:
-        raise InputException("Invalid version number")
+        raise InputException("Invalid commit hash")
 
 
 def has_command(command_words, input_words):

--- a/bot_test.py
+++ b/bot_test.py
@@ -294,9 +294,9 @@ async def test_release(doof, test_repo, event_loop, mocker, command):
 # pylint: disable=too-many-locals
 async def test_hotfix_release(doof, test_repo, event_loop, mocker):
     """
-    Doof should do a release when asked
+    Doof should do a hotfix when asked
     """
-    commit_hash = 'uthhg'
+    commit_hash = 'uthhg983u4thg9h5'
     version = '0.1.2'
     pr = ReleasePR(
         version=version,
@@ -312,7 +312,10 @@ async def test_hotfix_release(doof, test_repo, event_loop, mocker):
 
     wait_for_checkboxes_sync_mock = mocker.async_patch('bot.Bot.wait_for_checkboxes')
 
-    command_words = ['hotfix', version]
+    old_version = "0.1.1"
+    update_version_mock = mocker.patch('bot.update_version', autospec=True, return_value=old_version)
+
+    command_words = ['hotfix', commit_hash]
     me = 'mitodl_user'
     await doof.run_command(
         manager=me,
@@ -327,6 +330,7 @@ async def test_hotfix_release(doof, test_repo, event_loop, mocker):
         org=org,
         repo=repo,
     )
+    update_version_mock.assert_called_once_with("9.9.9")
     release_mock.assert_called_once_with(
         github_access_token=GITHUB_ACCESS,
         repo_url=test_repo.repo_url,

--- a/bot_test.py
+++ b/bot_test.py
@@ -291,6 +291,64 @@ async def test_release(doof, test_repo, event_loop, mocker, command):
     assert wait_for_checkboxes_sync_mock.called is True
 
 
+# pylint: disable=too-many-locals
+async def test_hotfix_release(doof, test_repo, event_loop, mocker):
+    """
+    Doof should do a release when asked
+    """
+    commit_hash = 'uthhg'
+    version = '0.1.2'
+    pr = ReleasePR(
+        version=version,
+        url='http://new.url',
+        body='Release PR body',
+    )
+    get_release_pr_mock = mocker.async_patch('bot.get_release_pr', side_effect=[None, pr, pr])
+    release_mock = mocker.async_patch('bot.release')
+
+    wait_for_deploy_sync_mock = mocker.async_patch('bot.wait_for_deploy')
+    authors = {'author1', 'author2'}
+    mocker.async_patch('bot.get_unchecked_authors', return_value=authors)
+
+    wait_for_checkboxes_sync_mock = mocker.async_patch('bot.Bot.wait_for_checkboxes')
+
+    command_words = ['hotfix', version]
+    me = 'mitodl_user'
+    await doof.run_command(
+        manager=me,
+        channel_id=test_repo.channel_id,
+        words=command_words,
+        loop=event_loop,
+    )
+
+    org, repo = get_org_and_repo(test_repo.repo_url)
+    get_release_pr_mock.assert_any_call(
+        github_access_token=GITHUB_ACCESS,
+        org=org,
+        repo=repo,
+    )
+    release_mock.assert_called_once_with(
+        github_access_token=GITHUB_ACCESS,
+        repo_url=test_repo.repo_url,
+        new_version=pr.version,
+        branch='release',
+        commit_hash=commit_hash,
+    )
+    wait_for_deploy_sync_mock.assert_called_once_with(
+        github_access_token=GITHUB_ACCESS,
+        repo_url=test_repo.repo_url,
+        hash_url=test_repo.rc_hash_url,
+        watch_branch='release-candidate',
+    )
+    assert doof.said("Now deploying to RC...")
+    for channel_id in [test_repo.channel_id, ANNOUNCEMENTS_CHANNEL.channel_id]:
+        assert doof.said(
+            "These people have commits in this release: {}".format(', '.join(authors)),
+            channel_id=channel_id,
+        )
+    assert wait_for_checkboxes_sync_mock.called is True
+
+
 @pytest.mark.parametrize("command", ['release', 'start release'])
 async def test_release_in_progress(doof, test_repo, event_loop, mocker, command):
     """

--- a/lib.py
+++ b/lib.py
@@ -25,7 +25,7 @@ ReleasePR = namedtuple("ReleasePR", ['version', 'url', 'body'])
 
 VERSION_RE = r'\d+\.\d+\.\d+'
 
-COMMIT_HASH_RE = r'"^[a-z0-9]*$"'
+COMMIT_HASH_RE = r'"^[a-z0-9]+$"'
 
 
 def parse_checkmarks(body):

--- a/lib.py
+++ b/lib.py
@@ -25,7 +25,7 @@ ReleasePR = namedtuple("ReleasePR", ['version', 'url', 'body'])
 
 VERSION_RE = r'\d+\.\d+\.\d+'
 
-COMMIT_HASH_RE = r'"^[a-z0-9]+$"'
+COMMIT_HASH_RE = r'^[a-z0-9]+$'
 
 
 def parse_checkmarks(body):

--- a/lib.py
+++ b/lib.py
@@ -25,6 +25,8 @@ ReleasePR = namedtuple("ReleasePR", ['version', 'url', 'body'])
 
 VERSION_RE = r'\d+\.\d+\.\d+'
 
+COMMIT_HASH_RE = r'"^[a-z0-9]*$"'
+
 
 def parse_checkmarks(body):
     """

--- a/release.py
+++ b/release.py
@@ -272,7 +272,7 @@ async def generate_release_pr(github_access_token, repo_url, old_version, new_ve
     )
 
 
-async def release(github_access_token, repo_url, new_version):
+async def release(github_access_token, repo_url, new_version, branch=None):
     """
     Run a release
 
@@ -283,8 +283,7 @@ async def release(github_access_token, repo_url, new_version):
     """
 
     await validate_dependencies()
-
-    async with init_working_dir(github_access_token, repo_url):
+    async with init_working_dir(github_access_token, repo_url, branch=branch):
         await check_call(["git", "checkout", "-qb", "release-candidate"])
         old_version = update_version(new_version)
         if parse_version(old_version) >= parse_version(new_version):

--- a/release.py
+++ b/release.py
@@ -272,7 +272,7 @@ async def generate_release_pr(github_access_token, repo_url, old_version, new_ve
     )
 
 
-async def release(github_access_token, repo_url, new_version, branch=None):
+async def release(github_access_token, repo_url, new_version, branch=None, hash=None):
     """
     Run a release
 
@@ -285,6 +285,8 @@ async def release(github_access_token, repo_url, new_version, branch=None):
     await validate_dependencies()
     async with init_working_dir(github_access_token, repo_url, branch=branch):
         await check_call(["git", "checkout", "-qb", "release-candidate"])
+        if hash:
+            await check_call(["git", "cherry-pick", hash])
         old_version = update_version(new_version)
         if parse_version(old_version) >= parse_version(new_version):
             raise ReleaseException("old version is {old} but the new version {new} is not newer".format(

--- a/release.py
+++ b/release.py
@@ -272,7 +272,7 @@ async def generate_release_pr(github_access_token, repo_url, old_version, new_ve
     )
 
 
-async def release(github_access_token, repo_url, new_version, branch=None, hash=None):
+async def release(github_access_token, repo_url, new_version, branch=None, commit_hash=None):
     """
     Run a release
 
@@ -280,13 +280,15 @@ async def release(github_access_token, repo_url, new_version, branch=None, hash=
         github_access_token (str): The github access token
         repo_url (str): URL for a repo
         new_version (str): The version of the new release
+        branch (str): The branch to initialize the release from
+        commit_hash (str): Commit hash to cherry pick in case of a hot fix
     """
 
     await validate_dependencies()
     async with init_working_dir(github_access_token, repo_url, branch=branch):
         await check_call(["git", "checkout", "-qb", "release-candidate"])
-        if hash:
-            await check_call(["git", "cherry-pick", hash])
+        if commit_hash:
+            await check_call(["git", "cherry-pick", commit_hash])
         old_version = update_version(new_version)
         if parse_version(old_version) >= parse_version(new_version):
             raise ReleaseException("old version is {old} but the new version {new} is not newer".format(

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ commands =
 
 setenv =
     COVERAGE_DIR = {toxinidir}/htmlcov
+passenv = *


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #201

#### What's this PR do?
Add a hotfix command to doof:
`@doof hotfix <commit_hash>`
This command will check if there is a release in progress, and will ask to close it first.
It will run the release script with `release` being the starting base branch, and then will cherry-pick the provided commit hash onto the release-candidate branch.

#### How should this be manually tested?
not sure yet

