### PR TITLE
Fix argument syntax error and add tests

### DIFF
--- a/async_subprocess.py
+++ b/async_subprocess.py
@@ -17,8 +17,9 @@ async def check_output(args, *, env=None, shell=False):
     Similar to subprocess.check_output but adapted for asyncio. Please add new arguments as needed.
     """
     create_func = asyncio.create_subprocess_shell if shell else asyncio.create_subprocess_exec
+    popenargs = [args] if shell else args
     proc = await create_func(
-        *args,
+        *popenargs,
         stdin=None,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -36,8 +37,9 @@ async def call(args, *, env=None, shell=False):
     Similar to subprocess.call but adapted for asyncio. Please add new arguments as needed.
     """
     create_func = asyncio.create_subprocess_shell if shell else asyncio.create_subprocess_exec
+    popenargs = [args] if shell else args
     proc = await create_func(
-        *args,
+        *popenargs,
         stdin=None,
         stdout=None,
         stderr=None,

--- a/async_subprocess_test.py
+++ b/async_subprocess_test.py
@@ -1,0 +1,92 @@
+"""Tests for async_subprocess_test"""
+import subprocess
+
+import pytest
+
+from async_subprocess import check_call, check_output, call
+from lib import async_wrapper
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("is_success", [True, False])
+async def test_check_call_shell(mocker, is_success):
+    """check_call should pass through a shell command string if shell is true"""
+    patched = mocker.async_patch("asyncio.create_subprocess_shell")
+    patched.return_value.wait = async_wrapper(lambda: 0 if is_success else 1)
+
+    cmd = "git checkout shell"
+    if is_success:
+        await check_call(cmd, shell=True)
+    else:
+        with pytest.raises(subprocess.CalledProcessError):
+            await check_call(cmd, shell=True)
+
+
+@pytest.mark.parametrize("is_success", [True, False])
+async def test_check_call_exec(mocker, is_success):
+    """check_call should use exec if shell is false"""
+    patched = mocker.async_patch("asyncio.create_subprocess_exec")
+    patched.return_value.wait = async_wrapper(lambda: 0 if is_success else 1)
+
+    args = ["git", "checkout", "shell"]
+    if is_success:
+        await check_call(args, shell=False)
+    else:
+        with pytest.raises(subprocess.CalledProcessError):
+            await check_call(args, shell=False)
+
+
+@pytest.mark.parametrize("is_success", [True, False])
+async def test_call_shell(mocker, is_success):
+    """call should pass through a shell command string if shell is true"""
+    patched = mocker.async_patch("asyncio.create_subprocess_shell")
+    expected_return = 0 if is_success else 1
+    patched.return_value.wait = async_wrapper(lambda: expected_return)
+
+    cmd = "git checkout shell"
+    assert await call(cmd, shell=True) == expected_return
+
+
+@pytest.mark.parametrize("is_success", [True, False])
+async def test_call_exec(mocker, is_success):
+    """call should use exec if shell is false"""
+    patched = mocker.async_patch("asyncio.create_subprocess_exec")
+    expected_return = 0 if is_success else 1
+    patched.return_value.wait = async_wrapper(lambda: expected_return)
+
+    args = ["git", "checkout", "shell"]
+    assert await call(args, shell=False) == expected_return
+
+
+@pytest.mark.parametrize("is_success", [True, False])
+async def test_check_output_shell(mocker, is_success):
+    """check_output should pass through a shell command string if shell is true"""
+    patched = mocker.async_patch("asyncio.create_subprocess_shell")
+    patched.return_value.wait = async_wrapper(lambda: 0 if is_success else 1)
+    expected_return = "some response text"
+    patched.return_value.communicate = async_wrapper(lambda input: (expected_return, None))
+
+    cmd = "git checkout shell"
+    if is_success:
+        assert await check_output(cmd, shell=True) == expected_return
+    else:
+        with pytest.raises(subprocess.CalledProcessError):
+            await check_output(cmd, shell=True)
+
+
+@pytest.mark.parametrize("is_success", [True, False])
+async def test_check_output_exec(mocker, is_success):
+    """check_output should use exec if shell is false"""
+    patched = mocker.async_patch("asyncio.create_subprocess_exec")
+    patched.return_value.wait = async_wrapper(lambda: 0 if is_success else 1)
+    expected_return = "some response text"
+    patched.return_value.communicate = async_wrapper(lambda input: (expected_return, None))
+
+    args = ["git", "checkout", "shell"]
+    if is_success:
+        assert await check_output(args, shell=False) == expected_return
+    else:
+        with pytest.raises(subprocess.CalledProcessError):
+            await check_output(args, shell=False)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #208 

#### What's this PR do?


#### How should this be manually tested?
In bot_local.py add these lines right at the top of `async def async_main():`:

    from lib import virtualenv
    async with virtualenv("python3", None) as (_, outer_environ):
        pass

On master you should see the same error from #208. On this branch you should see a different error about missing environment variables, or if you have those already set up, it should work fine.