### PR TITLE
Don't ask for merge if bot is checking release status after starting up

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -489,26 +489,27 @@ class Bot:
             org=org,
             repo=repo,
         )
-        await self.say(
-            channel_id=channel_id,
-            text="All checkboxes checked off. Release {version} is ready for the Merginator{name}!".format(
-                name=" " + format_user_id(manager) if manager else "",
-                version=pr.version
-            ),
-            attachments=[
-                {
-                    "fallback": "Finish the release",
-                    "callback_id": FINISH_RELEASE_ID,
-                    "actions": [
-                        {
-                            "name": "finish_release",
-                            "text": "Finish the release",
-                            "type": "button",
-                        }
-                    ]
-                }
-            ]
-        )
+        if speak_initial:
+            await self.say(
+                channel_id=channel_id,
+                text="All checkboxes checked off. Release {version} is ready for the Merginator{name}!".format(
+                    name=" " + format_user_id(manager) if manager else "",
+                    version=pr.version
+                ),
+                attachments=[
+                    {
+                        "fallback": "Finish the release",
+                        "callback_id": FINISH_RELEASE_ID,
+                        "actions": [
+                            {
+                                "name": "finish_release",
+                                "text": "Finish the release",
+                                "type": "button",
+                            }
+                        ]
+                    }
+                ]
+            )
 
     async def upload_to_pypitest(self, command_args):
         """

--- a/bot_local.py
+++ b/bot_local.py
@@ -55,6 +55,8 @@ async def async_main():
         repos_info=repos_info
     )
 
+    await bot.startup(loop=asyncio.get_event_loop())
+
     await bot.handle_message(
         manager='mitodl_user',
         channel_id=channel_id,

--- a/finish_release.py
+++ b/finish_release.py
@@ -55,7 +55,7 @@ async def set_release_date(version, timezone):
     await check_call(['git', 'checkout', 'release-candidate'])
 
     with open(release_filename) as f:
-        existing_note_lines = [line for line in f.readlines()]
+        existing_note_lines = f.readlines()
 
     with open(release_filename, "w") as f:
         for line in existing_note_lines:

--- a/github.py
+++ b/github.py
@@ -227,8 +227,7 @@ async def calculate_karma(*, github_access_token, begin_date, end_date):
                 )
             )
 
-    karma_list = [(k, v) for k, v in karma.items()]
-    karma_list = sorted(karma_list, key=lambda tup: tup[1], reverse=True)
+    karma_list = sorted(karma.items(), key=lambda tup: tup[1], reverse=True)
     return karma_list
 
 

--- a/release.py
+++ b/release.py
@@ -224,7 +224,7 @@ async def update_release_notes(old_version, new_version, *, base_branch):
     release_filename = "RELEASE.rst"
     try:
         with open(release_filename) as f:
-            existing_note_lines = [line for line in f.readlines()]
+            existing_note_lines = f.readlines()
     except FileNotFoundError:
         existing_note_lines = []
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes a bug where Doof asks the release manager to merge the PR whenever doof starts, which could be a few times a day.

#### How should this be manually tested?
Easiest to just merge then see if the problem occurs again.
