### PR TITLE
Add confirm button to finish release button, and a dismiss button when starting a release

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -234,6 +234,22 @@ class Bot:
         })
         resp.raise_for_status()
 
+    async def delete_message(self, *, channel_id, timestamp):
+        """
+        Deletes an existing message in slack
+
+        Args:
+            channel_id (str): The channel id
+            timestamp (str): The timestamp of the message to update
+        """
+        client = ClientWrapper()
+        resp = await client.post("https://slack.com/api/chat.delete", data={
+            "token": self.slack_access_token,
+            "channel": channel_id,
+            "ts": timestamp
+        })
+        resp.raise_for_status()
+
     async def say_with_attachment(self, *, channel_id, title, text, is_announcement=False):
         """
         Post a message in the Slack channel, putting the text in an attachment with markdown enabled
@@ -668,7 +684,14 @@ class Bot:
                                 "text": new_patch,
                                 "value": new_patch,
                                 "type": "button",
-                            }
+                            },
+                            {
+                                "name": "cancel",
+                                "text": "Cancel",
+                                "value": "cancel",
+                                "style": "danger",
+                                "type": "button",
+                            },
                         ]
                     }
                 ]
@@ -1053,7 +1076,6 @@ class Bot:
             webhook_dict (dict): The dict from Slack containing the webhook information
             loop (asyncio.events.AbstractEventLoop): The asyncio event loop
         """
-
         channel_id = webhook_dict['channel']['id']
         user_id = webhook_dict['user']['id']
         callback_id = webhook_dict['callback_id']
@@ -1091,6 +1113,14 @@ class Bot:
 
         elif callback_id == NEW_RELEASE_ID:
             repo_info = self.get_repo_info(channel_id)
+            name = webhook_dict['actions'][0]['value']
+            if name == "cancel":
+                await self.delete_message(
+                    channel_id=channel_id,
+                    timestamp=timestamp,
+                )
+                return
+
             version = webhook_dict['actions'][0]['value']
             await self.update_message(
                 channel_id=channel_id,

--- a/bot.py
+++ b/bot.py
@@ -521,6 +521,11 @@ class Bot:
                                 "name": "finish_release",
                                 "text": "Finish the release",
                                 "type": "button",
+                                "confirm": {
+                                    "title": "Are you sure?",
+                                    "ok_text": "Finish the release",
+                                    "dismiss_text": "Cancel",
+                                }
                             }
                         ]
                     }
@@ -687,7 +692,7 @@ class Bot:
                             },
                             {
                                 "name": "cancel",
-                                "text": "Cancel",
+                                "text": "Dismiss",
                                 "value": "cancel",
                                 "style": "danger",
                                 "type": "button",
@@ -1113,7 +1118,7 @@ class Bot:
 
         elif callback_id == NEW_RELEASE_ID:
             repo_info = self.get_repo_info(channel_id)
-            name = webhook_dict['actions'][0]['value']
+            name = webhook_dict['actions'][0]['name']
             if name == "cancel":
                 await self.delete_message(
                     channel_id=channel_id,

--- a/bot_test.py
+++ b/bot_test.py
@@ -185,7 +185,8 @@ async def test_release_notes_buttons(doof, test_repo, event_loop, mocker):
             'callback_id': 'new_release',
             'actions': [
                 {'name': 'minor_release', 'text': minor_version, 'value': minor_version, 'type': 'button'},
-                {'name': 'patch_release', 'text': patch_version, 'value': patch_version, 'type': 'button'}
+                {'name': 'patch_release', 'text': patch_version, 'value': patch_version, 'type': 'button'},
+                {'name': 'cancel', 'text': "Dismiss", 'value': "cancel", 'type': 'button', "style": "danger"}
             ]
         }
     ])
@@ -741,7 +742,8 @@ async def test_webhook_start_release(doof, test_repo, event_loop, mocker):
             },
             "actions": [
                 {
-                    "value": version
+                    "value": version,
+                    "name": "minor_release",
                 }
             ]
         },
@@ -778,7 +780,8 @@ async def test_webhook_start_release_fail(doof, event_loop, mocker):
                 },
                 "actions": [
                     {
-                        "value": version
+                        "value": version,
+                        "name": "minor_release",
                     }
                 ]
             },
@@ -933,7 +936,16 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
             ),
             attachments=[
                 {
-                    'actions': [{'name': 'finish_release', 'text': 'Finish the release', 'type': 'button'}],
+                    'actions': [
+                        {
+                            'name': 'finish_release', 'text': 'Finish the release', 'type': 'button',
+                            "confirm": {
+                                "title": "Are you sure?",
+                                "ok_text": "Finish the release",
+                                "dismiss_text": "Cancel",
+                            }
+                        },
+                    ],
                     'callback_id': 'finish_release', 'fallback': 'Finish the release'
                 }
             ]

--- a/bot_test.py
+++ b/bot_test.py
@@ -41,7 +41,7 @@ GITHUB_ACCESS = 'github'
 SLACK_ACCESS = 'slack'
 
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name, too-many-lines
 class DoofSpoof(Bot):
     """Testing bot"""
     def __init__(self):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #215 
Fixes #198 

#### What's this PR do?
 - Adds a confirmation button when finishing release. When the button is clicked a second message will say "Are you sure?". The user can then confirm or dismiss the finishing of the release.
 - Adds a dismiss button when `release notes` is run. When there is a release which can be created it will have a couple buttons for the next major or next minor version, like before, but there will also be a dismiss button to remove the message entirely.

#### How should this be manually tested?
Tests should pass. This uses webhooks and slack functionality so it's difficult to test outside of production.
