### PR TITLE
Make doof announce when library releases or uploads to pypi start

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -298,6 +298,11 @@ class Bot:
         repo_url = repo_info.repo_url
         channel_id = repo_info.channel_id
 
+        await self.say(
+            channel_id=channel_id,
+            text=f"Merging evil scheme {version} for {repo_info.name}...",
+        )
+
         await release(
             github_access_token=self.github_access_token,
             repo_url=repo_url,
@@ -635,7 +640,12 @@ class Bot:
         """
         repo_info = command_args.repo_info
         version = command_args.args[0]
+        pypi_server = "pypitest" if testing else "pypi"
 
+        await self.say(
+            channel_id=command_args.channel_id,
+            text=f"Publishing evil scheme {version} to {pypi_server}...",
+        )
         await upload_to_pypi(
             repo_info=repo_info,
             testing=testing,
@@ -645,10 +655,7 @@ class Bot:
 
         await self.say(
             channel_id=command_args.channel_id,
-            text='Successfully uploaded {version} to {pypi_server}.'.format(
-                version=version,
-                pypi_server="pypitest" if testing else "pypi",
-            ),
+            text=f'Successfully uploaded {version} to {pypi_server}.',
             is_announcement=True,
         )
 

--- a/bot_test.py
+++ b/bot_test.py
@@ -864,7 +864,7 @@ async def test_reset(doof, test_repo):
 
 
 @pytest.mark.parametrize("testing", [True, False])
-async def test_upload_to_pypi(doof, library_test_repo, event_loop, testing, mocker):
+async def test_upload_to_pypi(doof, library_test_repo, testing, mocker):
     """the upload_to_pypi command should start the upload process"""
     upload_to_pypi_patched = mocker.async_patch('bot.upload_to_pypi')
 
@@ -881,10 +881,14 @@ async def test_upload_to_pypi(doof, library_test_repo, event_loop, testing, mock
         manager='me',
         channel_id=library_test_repo.channel_id,
         words=['upload', 'to', pypi_server, version],
-        loop=event_loop,
     )
 
-    upload_to_pypi_patched.assert_called_once_with(repo_info=library_test_repo, testing=testing)
+    upload_to_pypi_patched.assert_called_once_with(
+        repo_info=library_test_repo,
+        testing=testing,
+        github_access_token=GITHUB_ACCESS,
+        version=version,
+    )
     assert doof.said(f"Successfully uploaded {version} to {pypi_server}.")
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #217 

#### What's this PR do?
Adds a couple of new messages from doof before uploading to PYPI and before a library project is merged. These are just to make it more obvious that Doof is working behind the scenes, even if it takes 30 seconds or so to respond.

#### How should this be manually tested?
Merge, then watch for new output from doof
