### PR TITLE
Tag users on wait for checkboxes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -541,22 +541,38 @@ class Bot:
             manager (str or None): User id for the release manager
             speak_initial (bool): If True, say that the plan isn't evil enough until all checkboxes are checked
         """
+        repo_url = repo_info.repo_url
         channel_id = repo_info.channel_id
-        if speak_initial:
-            await self.say(
-                channel_id=channel_id,
-                text="Wait, wait. Time out. My evil plan for {project} isn't evil enough "
-                "until all the checkboxes are checked...".format(
-                    project=repo_info.name,
-                )
-            )
-        org, repo = get_org_and_repo(repo_info.repo_url)
-
-        unchecked = await get_unchecked_authors(
+        org, repo = get_org_and_repo(repo_url)
+        unchecked_authors = await get_unchecked_authors(
             github_access_token=self.github_access_token,
             org=org,
             repo=repo,
         )
+        unchecked = await self.translate_slack_usernames(unchecked_authors)
+        pr = await get_release_pr(
+            github_access_token=self.github_access_token,
+            org=org,
+            repo=repo,
+        )
+
+        if speak_initial:
+            await self.say(
+                channel_id=channel_id,
+                text=(
+                    f"PR is up at {pr.url}."
+                    f" These people have commits in this release: {', '.join(unchecked)}"
+                ),
+                is_announcement=True
+            )
+            await self.say(
+                channel_id=channel_id,
+                text=(
+                    f"Wait, wait. Time out. My evil plan for {repo_info.name} isn't evil enough "
+                    "until all the checkboxes are checked..."
+                )
+            )
+        org, repo = get_org_and_repo(repo_info.repo_url)
 
         while unchecked:
             await asyncio.sleep(60)
@@ -576,11 +592,6 @@ class Bot:
                 )
             unchecked = unchecked_authors
 
-        pr = await get_release_pr(
-            github_access_token=self.github_access_token,
-            org=org,
-            repo=repo,
-        )
         if speak_initial:
             await self.say(
                 channel_id=channel_id,

--- a/bot_test.py
+++ b/bot_test.py
@@ -984,6 +984,7 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
                 }
             ]
         )
+        assert doof.said(f"PR is up at {pr.url}. These people have commits in this release: author1, author2, author3")
     assert doof.said(
         "Thanks for checking off your boxes author1, author3!"
     )

--- a/bot_test.py
+++ b/bot_test.py
@@ -984,7 +984,7 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
                 }
             ]
         )
-        assert doof.said(f"PR is up at {pr.url}. These people have commits in this release: author1, author2, author3")
+        assert doof.said(f"PR is up at {pr.url}. These people have commits in this release")
     assert doof.said(
         "Thanks for checking off your boxes author1, author3!"
     )


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #221 

#### What's this PR do?
We tag people when the release is started but not when `@doof wait for checkboxes` is run. 

#### How should this be manually tested?
Merge, then run a release and say `@doof wait for checkboxes`
