### PR TITLE
Fix graphql commands by lowering number of repositories requested

### DIFF
--- a/github.py
+++ b/github.py
@@ -14,7 +14,7 @@ KARMA_QUERY = """
 query {
 
   organization(login:"mitodl") {
-    repositories(first: 100, orderBy: {
+    repositories(first: 20, orderBy: {
       field: PUSHED_AT,
       direction: DESC
     }) {
@@ -45,7 +45,7 @@ query {
 NEEDS_REVIEW_QUERY = """
 query {
   organization(login:"mitodl") {
-    repositories(first: 100, orderBy: {
+    repositories(first: 20, orderBy: {
       field: PUSHED_AT,
       direction: DESC
     }) {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Our karma command is broken because github seems to respond with a 500 error on the query. If I lower the number of repositories to search from 100 to 20 the command works again. I think this is probably still sufficient for the most part.

The `NEEDS_REVIEW_QUERY` command works as is, but I changed it to also request the latest 20 repositories just in too much data here could cause a similar issue.

#### How should this be manually tested?
Merge then try the command. Alternatively you can copy the text from `KARMA_QUERY` in `github.py` and run it in the github [graphql explorer](https://developer.github.com/v4/explorer/)
