### PR TITLE
Fix list - set error, and have logged errors raise exceptions during tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -553,7 +553,7 @@ class Bot:
             org=org,
             repo=repo,
         )
-        unchecked = set(await self.translate_slack_usernames(unchecked_authors))
+        unchecked = await self.translate_slack_usernames(unchecked_authors)
         pr = await get_release_pr(
             github_access_token=self.github_access_token,
             org=org,

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,6 @@ import asyncio
 from collections import namedtuple
 from datetime import datetime
 import os
-import sys
 import logging
 import json
 import re

--- a/bot_test.py
+++ b/bot_test.py
@@ -60,7 +60,7 @@ class DoofSpoof(Bot):
         self.slack_users = []
         self.messages = {}
 
-    def lookup_users(self):
+    async def lookup_users(self):
         """Users in the channel"""
         return self.slack_users
 

--- a/conftest.py
+++ b/conftest.py
@@ -119,3 +119,15 @@ def mocker(mocker):  # pylint: disable=redefined-outer-name
 
     mocker.async_patch = async_patch
     return mocker
+
+
+def _raiser(message):
+    """Raise an exception"""
+    raise Exception(message)
+
+
+@pytest.fixture(autouse=True)
+def log_exception(mocker):
+    """Patch log.error and log.exception to raise an exception so tests do not silence it"""
+    mocker.patch('bot.log.exception', side_effect=_raiser)
+    mocker.patch('bot.log.error', side_effect=_raiser)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #226 

#### What's this PR do?
Changes the return value for `translate_slack_usernames` to return a set, and add a test fixture to fail on logged errors

#### How should this be manually tested?
Merge, then verify that it works
