### PR TITLE
Add command to generate release notes for issues merged over the last 7 days

### DIFF
--- a/bot_local.py
+++ b/bot_local.py
@@ -69,9 +69,7 @@ def main():
     """Main function"""
     loop = asyncio.get_event_loop()
     loop.run_until_complete(
-        loop.create_task(
-            async_main()
-        )
+        async_main()
     )
 
 

--- a/github.py
+++ b/github.py
@@ -307,8 +307,8 @@ def make_issue_release_notes(prs_and_issues):
                 (pr, parsed_issue)
             )
 
-    for issue_number, (issue, pr_list) in sorted(issue_to_prs.items(), key=lambda tup: tup[0]):
-        notes += f"{issue.title} (<{issue.url}|#{issue_number}>)\n"
+    for issue_number, (issue, _) in sorted(issue_to_prs.items(), key=lambda tup: tup[0]):
+        notes += f"- {issue.title} (<{issue.url}|#{issue_number}>)\n"
 
     return notes
 

--- a/github.py
+++ b/github.py
@@ -308,7 +308,7 @@ def make_issue_release_notes(prs_and_issues):
             )
 
     for issue_number, (issue, pr_list) in sorted(issue_to_prs.items(), key=lambda tup: tup[0]):
-        notes += f"<{issue.url}|#{issue_number}> {issue.title}\n"
+        notes += f"{issue.title} (<{issue.url}|#{issue_number}>)\n"
         for pr, parsed_issue in pr_list:
             notes += (
                 f" - {f'closed by' if parsed_issue.closes else 'related to'}"

--- a/github.py
+++ b/github.py
@@ -309,12 +309,6 @@ def make_issue_release_notes(prs_and_issues):
 
     for issue_number, (issue, pr_list) in sorted(issue_to_prs.items(), key=lambda tup: tup[0]):
         notes += f"{issue.title} (<{issue.url}|#{issue_number}>)\n"
-        for pr, parsed_issue in pr_list:
-            notes += (
-                f" - {f'closed by' if parsed_issue.closes else 'related to'}"
-                f" PR <{pr.url}|#{pr.number}>\n"
-            )
-        notes += "\n"
 
     return notes
 

--- a/github_test.py
+++ b/github_test.py
@@ -1,4 +1,5 @@
 """Tests for github functions"""
+from datetime import date, datetime, timezone
 import json
 import os
 
@@ -15,12 +16,26 @@ from constants import (
 from github import (
     create_pr,
     calculate_karma,
+    fetch_issues_for_pull_requests,
+    fetch_pull_requests_since_date,
+    get_issue,
     get_org_and_repo,
     get_status_of_pr,
     github_auth_headers,
+    make_issue_release_notes,
+    make_pull_requests_query,
     needs_review,
     KARMA_QUERY,
     NEEDS_REVIEW_QUERY,
+    PullRequest,
+)
+from test_util import (
+    async_gen_wrapper,
+    make_issue,
+    make_parsed_issue,
+    make_pr,
+    TEST_ORG,
+    TEST_REPO,
 )
 
 
@@ -200,3 +215,180 @@ async def test_get_status_of_pr(mocker, status_code, status_data, expected_statu
         ref=branch,
     )
     patched.assert_called_once_with(mocker.ANY, endpoint, headers=github_auth_headers(token))
+
+
+async def test_fetch_pull_requests_since_date(mocker):  # pylint: disable=too-many-locals
+    """fetch_pull_requests_since_date should construct a graphql query and fetch the results of that query"""
+    org = "org"
+    repo = "repo"
+    token = "token"
+    cursor = 'some cursor'
+    pr_number = 12345
+    url = 'http://url.com'
+    title = "A PR title"
+    body = "PR body"
+    updated_in_bounds = datetime(2020, 1, 2, tzinfo=timezone.utc)
+    updated_out_bounds = datetime(2019, 1, 1, tzinfo=timezone.utc)
+    since = date(2020, 1, 1)
+
+    edge_in_bounds = {
+        'cursor': cursor,
+        'node': {
+            'number': pr_number,
+            'url': url,
+            'updatedAt': updated_in_bounds.isoformat(),
+            'title': title,
+            'body': body,
+        }
+    }
+    edge_out_bounds = {
+        'cursor': None,
+        'node': {
+            'number': pr_number,
+            'url': url,
+            'updatedAt': updated_out_bounds.isoformat(),
+            'title': title,
+            'body': body,
+        }
+    }
+    result_in_bounds = {'data': {'organization': {'repository': {'pullRequests': {'edges': [edge_in_bounds]}}}}}
+    result_out_bounds = {'data': {'organization': {'repository': {'pullRequests': {'edges': [edge_out_bounds]}}}}}
+
+    patched = mocker.async_patch('github.run_query', side_effect=[result_in_bounds, result_out_bounds])
+
+    prs = [pr async for pr in fetch_pull_requests_since_date(
+        github_access_token=token,
+        org=org,
+        repo=repo,
+        since=since
+    )]
+    assert prs == (
+        [PullRequest(
+            number=pr_number,
+            title=title,
+            body=body,
+            updatedAt=updated_in_bounds.date(),
+            org=org,
+            repo=repo,
+            url=url,
+        )]
+    )
+    patched.assert_any_call(
+        github_access_token=token,
+        query=make_pull_requests_query(org=org, repo=repo, cursor=None),
+    )
+    patched.assert_any_call(
+        github_access_token=token,
+        query=make_pull_requests_query(org=org, repo=repo, cursor=cursor),
+    )
+
+
+async def test_fetch_issues_for_pull_requests(mocker):
+    """fetch_issues_for_pull_requests should parse pull request text and look for issue links and numbers"""
+    token = "a token"
+
+    pr1 = make_pr(987, "Hey issue #345 and closes #456")
+    pr2 = make_pr(989, "Another reference to issue #456")
+    issues = {}
+    for number in 345, 456:
+        issues[number] = make_issue(number)
+
+    def _get_issue(*, issue_number, **kwargs):  # pylint: disable=unused-argument
+        """Helper function to look up issue"""
+        return issues[issue_number]
+
+    patched = mocker.async_patch('github.get_issue', side_effect=_get_issue)
+
+    prs_and_issues = [tup async for tup in fetch_issues_for_pull_requests(
+        github_access_token=token,
+        pull_requests=async_gen_wrapper([pr1, pr2]),
+    )]
+    assert prs_and_issues == [
+        (pr1, [
+            (issues[345], make_parsed_issue(345, False)),
+            (issues[456], make_parsed_issue(456, True)),
+        ]),
+        (pr2, [
+            (issues[456], make_parsed_issue(456, False))
+        ])
+    ]
+    for number in 345, 456:
+        patched.assert_any_call(
+            github_access_token=token,
+            org=TEST_ORG,
+            repo=TEST_REPO,
+            issue_number=number,
+        )
+
+
+async def test_make_issue_release_notes():
+    """make_issue_release_notes should create readable release notes for public consumption"""
+    issue123, issue456 = make_issue(123), make_issue(456)
+    pr1, pr2 = make_pr(1234, "fixes #123 and related to #456"), make_pr(3456, "Related to #456")
+    prs_and_issues = [
+        (pr1, [
+            (issue123, make_parsed_issue(345, False)),
+            (issue456, make_parsed_issue(456, True)),
+        ]),
+        (pr2, [
+            (issue456, make_parsed_issue(456, False))
+        ])
+    ]
+
+    assert make_issue_release_notes(prs_and_issues) == f"""<{issue123.url}|#{issue123.number}> {issue123.title}
+ - related to PR <{pr1.url}|#{pr1.number}>
+
+<{issue456.url}|#{issue456.number}> {issue456.title}
+ - closed by PR <{pr1.url}|#{pr1.number}>
+ - related to PR <{pr2.url}|#{pr2.number}>
+
+"""
+
+
+async def test_get_issue(mocker):
+    """get_issue should fetch an issue via the REST API"""
+    issue = make_issue(12345)
+    token = "token"
+    issue_json = {
+        "title": issue.title,
+        "number": issue.number,
+        "state": issue.status,
+        "updated_at": issue.updatedAt.isoformat(),
+        "html_url": issue.url,
+    }
+    response = mocker.Mock(json=mocker.Mock(return_value=issue_json))
+    patched = mocker.async_patch('client_wrapper.ClientWrapper.get', return_value=response)
+
+    assert await get_issue(
+        github_access_token=token,
+        org=TEST_ORG,
+        repo=TEST_REPO,
+        issue_number=issue.number,
+    ) == issue
+    patched.assert_called_once_with(
+        mocker.ANY,
+        f"https://api.github.com/repos/{TEST_ORG}/{TEST_REPO}/issues/{issue.number}",
+        headers=github_auth_headers(token),
+    )
+
+
+async def test_get_issue_but_its_a_pr(mocker):
+    """get_issue should return None if it's actually fetching a PR"""
+    issue_json = {
+        "pull_request": "some pull request info"
+    }
+    response = mocker.Mock(json=mocker.Mock(return_value=issue_json))
+    patched = mocker.async_patch('client_wrapper.ClientWrapper.get', return_value=response)
+    token = "token"
+
+    assert await get_issue(
+        github_access_token=token,
+        org=TEST_ORG,
+        repo=TEST_REPO,
+        issue_number=1234,
+    ) is None
+    patched.assert_called_once_with(
+        mocker.ANY,
+        f"https://api.github.com/repos/{TEST_ORG}/{TEST_REPO}/issues/1234",
+        headers=github_auth_headers(token),
+    )

--- a/github_test.py
+++ b/github_test.py
@@ -336,12 +336,7 @@ async def test_make_issue_release_notes():
     ]
 
     assert make_issue_release_notes(prs_and_issues) == f"""{issue123.title} (<{issue123.url}|#{issue123.number}>)
- - related to PR <{pr1.url}|#{pr1.number}>
-
 {issue456.title} (<{issue456.url}|#{issue456.number}>)
- - closed by PR <{pr1.url}|#{pr1.number}>
- - related to PR <{pr2.url}|#{pr2.number}>
-
 """
 
 

--- a/github_test.py
+++ b/github_test.py
@@ -335,10 +335,10 @@ async def test_make_issue_release_notes():
         ])
     ]
 
-    assert make_issue_release_notes(prs_and_issues) == f"""<{issue123.url}|#{issue123.number}> {issue123.title}
+    assert make_issue_release_notes(prs_and_issues) == f"""{issue123.title} (<{issue123.url}|#{issue123.number}>)
  - related to PR <{pr1.url}|#{pr1.number}>
 
-<{issue456.url}|#{issue456.number}> {issue456.title}
+{issue456.title} (<{issue456.url}|#{issue456.number}>)
  - closed by PR <{pr1.url}|#{pr1.number}>
  - related to PR <{pr2.url}|#{pr2.number}>
 

--- a/github_test.py
+++ b/github_test.py
@@ -335,8 +335,8 @@ async def test_make_issue_release_notes():
         ])
     ]
 
-    assert make_issue_release_notes(prs_and_issues) == f"""{issue123.title} (<{issue123.url}|#{issue123.number}>)
-{issue456.title} (<{issue456.url}|#{issue456.number}>)
+    assert make_issue_release_notes(prs_and_issues) == f"""- {issue123.title} (<{issue123.url}|#{issue123.number}>)
+- {issue456.title} (<{issue456.url}|#{issue456.number}>)
 """
 
 

--- a/markdown.py
+++ b/markdown.py
@@ -1,0 +1,54 @@
+"""Markdown parsing functions"""
+
+from collections import namedtuple
+import re
+
+
+ParsedIssue = namedtuple("ParsedIssue", ["issue_number", "closes", "org", "repo"])
+
+
+def _make_issue_number_regex():
+    """Create regex to extract issue number and other useful things"""
+    # See https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls
+
+    closes_prefix = r"(?P<closes>(fixes|closes))?(\s+|^)"
+    # org and repo are named different because it's not allowed to have two groups named the same in the regex
+    # even if they are separated with a |
+    prefixes = [
+        r"(https://github.com/(?P<org1>[^/\s]+)/(?P<repo1>[^/\s]+)/issues/)",
+        r"(?P<org2>[^/\s]+)/(?P<repo2>[^/\s]+)#",
+        r"#",
+        r"GH-",
+    ]
+    issue_number_pattern = r"(?P<issue_number>\d+)"
+    pattern = f"{closes_prefix}({'|'.join([f'{prefix}' for prefix in prefixes])}){issue_number_pattern}"
+    return re.compile(pattern, re.IGNORECASE)
+
+
+REGEX = _make_issue_number_regex()
+
+
+def parse_linked_issues(pull_request):
+    """
+    Parse markdown for linked issues
+
+    Args:
+        pull_request (PullRequest): Information about a pull request
+
+    Returns:
+        list of ParsedIssue: parsed issue numbers and their context
+    """
+    parsed_issues = []
+    for match in REGEX.finditer(pull_request.body):
+        groups = match.groupdict()
+        parsed_issues.append(ParsedIssue(
+            issue_number=int(groups.get("issue_number")),
+            # org1 and org2 match different groups in the regex. There should only be one which matches since they
+            # are separated with an |.
+            # If org or repo are None, that means the issue number was provided without that context, which means
+            # it's part of the same org/repo as the pull request.
+            org=groups.get("org1") or groups.get("org2") or pull_request.org,
+            repo=groups.get("repo1") or groups.get("repo2") or pull_request.repo,
+            closes=groups.get("closes") is not None,
+        ))
+    return parsed_issues

--- a/markdown_test.py
+++ b/markdown_test.py
@@ -1,0 +1,54 @@
+"""Tests for markdown parser"""
+import pytest
+
+from github import PullRequest
+from markdown import parse_linked_issues, ParsedIssue
+
+
+ORG = "default_org"
+REPO = "default_repo"
+
+
+@pytest.mark.parametrize("input_text, expected_output", [
+    # Linked issues should be parsed, even ending with comma
+    [" see issue https://github.com/jlord/sheetsee.js/issues/26, which is ", [
+        ParsedIssue(issue_number=26, org="jlord", repo="sheetsee.js", closes=False),
+    ]],
+    # Test that closes will close an issue, and a lack of close will not close it
+    ["Closes #9876543, related to #76543, fixes #44", [
+        ParsedIssue(issue_number=9876543, org=ORG, repo=REPO, closes=True),
+        ParsedIssue(issue_number=76543, org=ORG, repo=REPO, closes=False),
+        ParsedIssue(issue_number=44, org=ORG, repo=REPO, closes=True),
+    ]],
+    # Test that #xx and org/repo#xx can coexist and not be parsed as each other
+    ["see #769, mitodl/mitxpro#94 and mitodl/open-discussions#76, and also #123 for more info", [
+        ParsedIssue(issue_number=769, org=ORG, repo=REPO, closes=False),
+        ParsedIssue(issue_number=94, org="mitodl", repo="mitxpro", closes=False),
+        ParsedIssue(issue_number=76, org="mitodl", repo="open-discussions", closes=False),
+        ParsedIssue(issue_number=123, org=ORG, repo=REPO, closes=False),
+    ]],
+    # No issue links should be parsed
+    ["nothing to see here", []],
+    # Parse GH-
+    ["We don't use issue links like GH-543", [
+        ParsedIssue(issue_number=543, org=ORG, repo=REPO, closes=False)
+    ]],
+    # ignore issues which are links
+    ["Catch buffer overruns [#4104](https://github-redirect.dependabot.com/python-pillow/Pillow/issues/4104)", []],
+    # start issue at beginning of string
+    ["#654 is the issue", [
+        ParsedIssue(issue_number=654, org=ORG, repo=REPO, closes=False),
+    ]]
+])
+def test_parser(input_text, expected_output):
+    """Test that parser is producing expected output"""
+    pr = PullRequest(
+        body=input_text,
+        number=1234,
+        title="title",
+        updatedAt=None,
+        org=ORG,
+        repo=REPO,
+        url=f"https://github.com/{ORG}/{REPO}.git",
+    )
+    assert parse_linked_issues(pr) == expected_output

--- a/test_util.py
+++ b/test_util.py
@@ -1,5 +1,6 @@
 """Utility functions for testing"""
 from contextlib import asynccontextmanager, contextmanager
+from datetime import datetime, timezone
 import gzip
 import os
 from shutil import copyfileobj
@@ -10,6 +11,12 @@ from tempfile import (
 import subprocess
 
 from constants import SCRIPT_DIR
+from github import Issue, PullRequest
+from markdown import ParsedIssue
+
+
+TEST_ORG = 'test-org'
+TEST_REPO = 'test-repo'
 
 
 def sync_check_call(*args, cwd, **kwargs):
@@ -56,3 +63,45 @@ def async_context_manager_yielder(value):
     async def async_context_manager(*args, **kwargs):  # pylint: disable=unused-argument
         yield value
     return async_context_manager
+
+
+async def async_gen_wrapper(iterable):
+    """Helper method to convert an iterable to an async iterable"""
+    for item in iterable:
+        yield item
+
+
+def make_issue(number):
+    """Helper method to create a fake Issue and ParsedIssue given a number"""
+    return Issue(
+        number=number,
+        title=f"Issue {number}",
+        status="closed",
+        org=TEST_ORG,
+        repo=TEST_REPO,
+        updatedAt=datetime(2019, 6, 5, tzinfo=timezone.utc),
+        url="http://b.net/example/uri"
+    )
+
+
+def make_parsed_issue(number, closes):
+    """Helper method to create a fake ParsedIssue given a number"""
+    return ParsedIssue(
+        issue_number=number,
+        closes=closes,
+        org=TEST_ORG,
+        repo=TEST_REPO,
+    )
+
+
+def make_pr(number, body):
+    """Helper method to create a fake PullRequest"""
+    return PullRequest(
+        body=body,
+        title="PR title",
+        number=number,
+        org=TEST_ORG,
+        repo=TEST_REPO,
+        url="http://a.net/example/url",
+        updatedAt=datetime(2020, 1, 1, tzinfo=timezone.utc).date()
+    )


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #220 

#### What's this PR do?
Adds a command to generate release notes over a period of time, rather than just for the last release. Also, this will look up related issues and print information about it.

#### How should this be manually tested?
Enter the virtualenv and run `python3 bot_local.py mitxpro-eng issue release notes`. You should see some output after a few seconds.

#### Any background context you want to provide?
This is intended to be a first draft of the feature. It will print to the chat so people can look at the notes and see what changes will be made. Once we have a firm idea on what the release notes should look like, we will need to add a command to send the release notes as an email.
