### PR TITLE
Fix release version bug, and fix to correct users listed in wait for checkboxes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -458,7 +458,7 @@ class Bot:
         version = await get_version_tag(
             github_access_token=self.github_access_token,
             repo_url=repo_url,
-            commit_hash="release",
+            commit_hash="origin/release",
         )
 
         await wait_for_deploy(

--- a/bot.py
+++ b/bot.py
@@ -548,12 +548,11 @@ class Bot:
         repo_url = repo_info.repo_url
         channel_id = repo_info.channel_id
         org, repo = get_org_and_repo(repo_url)
-        unchecked_authors = await get_unchecked_authors(
+        prev_unchecked_authors = await get_unchecked_authors(
             github_access_token=self.github_access_token,
             org=org,
             repo=repo,
         )
-        unchecked = await self.translate_slack_usernames(unchecked_authors)
         pr = await get_release_pr(
             github_access_token=self.github_access_token,
             org=org,
@@ -565,7 +564,8 @@ class Bot:
                 channel_id=channel_id,
                 text=(
                     f"PR is up at {pr.url}."
-                    f" These people have commits in this release: {', '.join(unchecked)}"
+                    f" These people have commits in this release: "
+                    f"{', '.join(await self.translate_slack_usernames(prev_unchecked_authors))}"
                 ),
                 is_announcement=True
             )
@@ -578,23 +578,23 @@ class Bot:
             )
         org, repo = get_org_and_repo(repo_info.repo_url)
 
-        while unchecked:
+        while prev_unchecked_authors:
             await asyncio.sleep(60)
 
-            unchecked_authors = await get_unchecked_authors(
+            new_unchecked_authors = await get_unchecked_authors(
                 github_access_token=self.github_access_token,
                 org=org,
                 repo=repo,
             )
 
-            newly_checked = unchecked - unchecked_authors
+            newly_checked = prev_unchecked_authors - new_unchecked_authors
             if newly_checked:
                 await self.say(
                     channel_id=channel_id,
                     text=f"Thanks for checking off your boxes "
                     f"{', '.join(sorted(await self.translate_slack_usernames(newly_checked)))}!",
                 )
-            unchecked = unchecked_authors
+            prev_unchecked_authors = new_unchecked_authors
 
         if speak_initial:
             await self.say(

--- a/bot_test.py
+++ b/bot_test.py
@@ -1163,7 +1163,7 @@ async def test_wait_for_deploy_prod(doof, test_repo, mocker):
     get_version_tag_mock.assert_called_once_with(
         github_access_token=GITHUB_ACCESS,
         repo_url=test_repo.repo_url,
-        commit_hash="release",
+        commit_hash="origin/release",
     )
     assert doof.said('has been released to production')
     wait_for_deploy_mock.assert_called_once_with(

--- a/bot_test.py
+++ b/bot_test.py
@@ -980,6 +980,14 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
         {'author2'},
         set(),
     ])
+    doof.slack_users = [
+        {"profile": {"real_name": name}, "id": username} for (name, username) in [
+            ("Author 1", "author1"),
+            ("Author 2", "author2"),
+            ("Author 3", "author3"),
+        ]
+    ]
+
     sleep_sync_mock = mocker.async_patch('asyncio.sleep')
 
     me = 'mitodl_user'
@@ -1021,11 +1029,14 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
             ]
         )
         assert doof.said(f"PR is up at {pr.url}. These people have commits in this release")
-    assert doof.said(
-        "Thanks for checking off your boxes author1, author3!"
+    assert not doof.said(
+        "Thanks for checking off your boxes <@author1>, <@author2>, <@author3>!"
     )
     assert doof.said(
-        "Thanks for checking off your boxes author2!"
+        "Thanks for checking off your boxes <@author1>, <@author3>!"
+    )
+    assert doof.said(
+        "Thanks for checking off your boxes <@author2>!"
     )
 
 

--- a/lib.py
+++ b/lib.py
@@ -390,6 +390,7 @@ async def init_working_dir(github_access_token, repo_url, *, branch=None):
     with TemporaryDirectory() as directory:
         # from http://stackoverflow.com/questions/2411031/how-do-i-clone-into-a-non-empty-directory
         await check_call(["git", "init", "-q"], cwd=directory)
+        await check_call(["git", "config", "push.default", "simple"], cwd=directory)
         await check_call(["git", "remote", "add", "origin", url], cwd=directory)
         await check_call(["git", "fetch", "--tags", "-q"], cwd=directory)
         await check_call(["git", "checkout", branch, "-q"], cwd=directory)

--- a/release_test.py
+++ b/release_test.py
@@ -478,7 +478,7 @@ async def test_get_version_tag(mocker):
     assert await get_version_tag(
         github_access_token='github',
         repo_url='http://github.com/mitodl/doof.git',
-        commit_hash='origin/commit',
+        commit_hash='commit',
     ) == a_hash.decode()
 
 

--- a/release_test.py
+++ b/release_test.py
@@ -477,7 +477,7 @@ async def test_get_version_tag(mocker):
     assert await get_version_tag(
         github_access_token='github',
         repo_url='http://github.com/mitodl/doof.git',
-        commit_hash='commit',
+        commit_hash='origin/commit',
     ) == a_hash.decode()
 
 

--- a/release_test.py
+++ b/release_test.py
@@ -228,6 +228,7 @@ async def test_init_working_dir(mocker, branch):
     calls = check_call_mock.call_args_list
     assert [call[0][0] for call in calls] == [
         ['git', 'init', '-q'],
+        ['git', 'config', 'push.default', 'simple'],
         ['git', 'remote', 'add', 'origin', url_with_access_token(access_token, repo_url)],
         ['git', 'fetch', '--tags', '-q'],
         ['git', 'checkout', "master" if branch is None else branch, '-q'],

--- a/version.py
+++ b/version.py
@@ -9,5 +9,8 @@ from release import init_working_dir
 async def get_version_tag(*, github_access_token, repo_url, commit_hash):
     """Determines the version tag (or None) of the given commit hash"""
     async with init_working_dir(github_access_token, repo_url) as working_dir:
-        output = await check_output(["git", "tag", "-l", "--points-at", commit_hash], cwd=working_dir)
+        output = await check_output(
+            ["git", "tag", "-l", "--points-at", f"origin/{commit_hash}"],
+            cwd=working_dir
+        )
         return output.decode().strip()

--- a/version.py
+++ b/version.py
@@ -10,7 +10,7 @@ async def get_version_tag(*, github_access_token, repo_url, commit_hash):
     """Determines the version tag (or None) of the given commit hash"""
     async with init_working_dir(github_access_token, repo_url) as working_dir:
         output = await check_output(
-            ["git", "tag", "-l", "--points-at", f"origin/{commit_hash}"],
+            ["git", "tag", "-l", "--points-at", commit_hash],
             cwd=working_dir
         )
         return output.decode().strip()


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
 - Fixes checkbox bug introduced in #222. The first loop, the slack usernames were compared with the slack full names, which meant Doof was incorrectly tagging the users who had checked off their boxes
 - Fixes release bug caused by a change in #218. Doof will add `origin/` when calling `get_version_tag` so that it can look up the branch. Previously the function looked for a local branch which didn't exist.
 - Adds `git config push.default simple` to silence a warning in the output

#### How should this be manually tested?
Merge, then verify that releases work properly

