### PR TITLE
Doof should say that all checkboxes are checked after restarting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -584,6 +584,9 @@ class Bot:
         org, repo = get_org_and_repo(repo_info.repo_url)
 
         while prev_unchecked_authors:
+            # There are still checkboxes, so we want to have doof say that all checkboxes are checked off
+            # even after doof restarts.
+            speak_initial = True
             await asyncio.sleep(60)
 
             new_unchecked_authors = await get_unchecked_authors(

--- a/bot_test.py
+++ b/bot_test.py
@@ -983,7 +983,7 @@ async def test_help(doof):
     [False, True],
 ])
 async def test_wait_for_checkboxes(
-    mocker, doof, test_repo, speak_initial, has_checkboxes
+        mocker, doof, test_repo, speak_initial, has_checkboxes
 ):
     """wait_for_checkboxes should poll github, parse checkboxes and see if all are checked"""
     org, repo = get_org_and_repo(test_repo.repo_url)

--- a/bot_test.py
+++ b/bot_test.py
@@ -976,8 +976,15 @@ async def test_help(doof):
     assert doof.said("*help*: Show available commands")
 
 
-@pytest.mark.parametrize("speak_initial", [True, False])
-async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
+@pytest.mark.parametrize("speak_initial, has_checkboxes", [
+    [True, False],
+    [True, True],
+    [False, False],
+    [False, True],
+])
+async def test_wait_for_checkboxes(
+    mocker, doof, test_repo, speak_initial, has_checkboxes
+):
     """wait_for_checkboxes should poll github, parse checkboxes and see if all are checked"""
     org, repo = get_org_and_repo(test_repo.repo_url)
 
@@ -987,7 +994,7 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
         {'author1', 'author2', 'author3'},
         {'author2'},
         set(),
-    ])
+    ] if has_checkboxes else [set()])
     doof.slack_users = [
         {"profile": {"real_name": name}, "id": username} for (name, username) in [
             ("Author 1", "author1"),
@@ -1011,12 +1018,12 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
         org=org,
         repo=repo,
     )
-    assert get_unchecked_patch.call_count == 3
-    assert sleep_sync_mock.call_count == 2
+    assert get_unchecked_patch.call_count == (3 if has_checkboxes else 1)
+    assert sleep_sync_mock.call_count == (2 if has_checkboxes else 0)
     get_release_pr_mock.assert_called_once_with(github_access_token=GITHUB_ACCESS, org=org, repo=repo)
-    if speak_initial:
+    if speak_initial or has_checkboxes:
         assert doof.said(
-            "Release {version} is ready for the Merginator {name}".format(
+            "All checkboxes checked off. Release {version} is ready for the Merginator {name}".format(
                 version=pr.version,
                 name=format_user_id(me),
             ),
@@ -1036,16 +1043,18 @@ async def test_wait_for_checkboxes(mocker, doof, test_repo, speak_initial):
                 }
             ]
         )
+    if speak_initial:
         assert doof.said(f"PR is up at {pr.url}. These people have commits in this release")
-    assert not doof.said(
-        "Thanks for checking off your boxes <@author1>, <@author2>, <@author3>!"
-    )
-    assert doof.said(
-        "Thanks for checking off your boxes <@author1>, <@author3>!"
-    )
-    assert doof.said(
-        "Thanks for checking off your boxes <@author2>!"
-    )
+    if has_checkboxes:
+        assert not doof.said(
+            "Thanks for checking off your boxes <@author1>, <@author2>, <@author3>!"
+        )
+        assert doof.said(
+            "Thanks for checking off your boxes <@author1>, <@author3>!"
+        )
+        assert doof.said(
+            "Thanks for checking off your boxes <@author2>!"
+        )
 
 
 # pylint: disable=too-many-arguments


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #239 

#### What's this PR do?
When Doof restarts, Doof starts a task to wait for checkboxes. Doof doesn't say that people need to check off their boxes at this point, or that all checkboxes are checked off, because it could already have been said before Doof restarted.

This PR makes a tweak so that Doof will say that all checkboxes are checked off if Doof recently saw that a checkbox had been checked off. If Doof restarts afterwards Doof should still refrain from saying anything, so we shouldn't see Doof saying the same thing multiple times.

One exception is a case where a person checks off their box, then Doof restarts within a minute of the box being checked. In that case Doof should say something but won't say anything. I'm not sure how to deal with that case without some long term state, or Doof going through the Slack channels to see what he already said. But this should be a rare circumstance.

#### How should this be manually tested?
N/A
