### PR TITLE
Use explicit mapping of names

### DIFF
--- a/bot_test.py
+++ b/bot_test.py
@@ -996,11 +996,8 @@ async def test_wait_for_checkboxes(
         set(),
     ] if has_checkboxes else [set()])
     doof.slack_users = [
-        {"profile": {"real_name": name}, "id": username} for (name, username) in [
-            ("Author 1", "author1"),
-            ("Author 2", "author2"),
-            ("Author 3", "author3"),
-        ]
+        {"profile": {"real_name_normalized": name}, "id": name} for name in [
+            "author1", "author2", "author3"]
     ]
 
     sleep_sync_mock = mocker.async_patch('asyncio.sleep')

--- a/lib_test.py
+++ b/lib_test.py
@@ -195,25 +195,25 @@ async def test_reformatted_full_name():
 FAKE_SLACK_USERS = [
     {
         'profile': {
-            'real_name': 'George Schneeloch',
+            'real_name_normalized': 'George Schneeloch',
         },
         'id': 'U12345',
     },
     {
         'profile': {
-            'real_name': 'Sar Haidar'
+            'real_name_normalized': 'Sar Haidar'
         },
         'id': 'U65432'
     },
     {
         'profile': {
-            'real_name': 'Sarah H'
+            'real_name_normalized': 'Sarah H'
         },
         'id': 'U13986'
     },
     {
         'profile': {
-            'real_name': 'Tasawer Nawaz'
+            'real_name_normalized': 'Tasawer Nawaz'
         },
         'id': 'U9876'
     }
@@ -223,10 +223,12 @@ FAKE_SLACK_USERS = [
 async def test_match_users():
     """match_users should use the Levensthein distance to compare usernames"""
     assert match_user(FAKE_SLACK_USERS, "George Schneeloch") == "<@U12345>"
-    assert match_user(FAKE_SLACK_USERS, "George Schneelock") == "<@U12345>"
-    assert match_user(FAKE_SLACK_USERS, "George") == "<@U12345>"
-    assert match_user(FAKE_SLACK_USERS, 'sar') == '<@U65432>'
-    assert match_user(FAKE_SLACK_USERS, 'tasawernawaz') == '<@U9876>'
+    assert match_user(FAKE_SLACK_USERS, "George Schneelock") == "George Schneelock"
+    assert match_user(FAKE_SLACK_USERS, "George") == "George"
+    assert match_user(FAKE_SLACK_USERS, 'sar') == 'sar'
+    assert match_user(FAKE_SLACK_USERS, 'Sar Haidar') == '<@U65432>'
+    assert match_user(FAKE_SLACK_USERS, 'tasawernawaz') == 'tasawernawaz'
+    assert match_user(FAKE_SLACK_USERS, 'Tasawer Nawaz') == '<@U9876>'
 
 
 async def test_url_with_access_token():


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #241 

#### What's this PR do?
Instead of making a best guess, Doof will see that the name matches exactly with the name in the PR. If yes, the name will be tagged in the slack message, otherwise the name will be used as is without tagging the user.

#### How should this be manually tested?
N/A