### PR TITLE
Migrate to slack conversations API

### DIFF
--- a/bot_test.py
+++ b/bot_test.py
@@ -221,7 +221,7 @@ async def test_release_notes_buttons(doof, test_repo, test_repo_directory, mocke
             ]
         }
     ])
-    assert not doof.said(f"And also! There is a release already in progress")
+    assert not doof.said("And also! There is a release already in progress")
 
 
 async def test_version(doof, test_repo, mocker):

--- a/slack.py
+++ b/slack.py
@@ -14,19 +14,12 @@ async def get_channels_info(slack_access_token):
     """
     client = ClientWrapper()
     # public channels
-    resp = await client.post("https://slack.com/api/channels.list", data={
-        "token": slack_access_token
+    resp = await client.post("https://slack.com/api/conversations.list", data={
+        "token": slack_access_token,
+        "types": "public_channel,private_channel"
     })
     resp.raise_for_status()
     channels = resp.json()['channels']
     channels_map = {channel['name']: channel['id'] for channel in channels}
 
-    # private channels
-    resp = await client.post("https://slack.com/api/groups.list", data={
-        "token": slack_access_token
-    })
-    resp.raise_for_status()
-    groups = resp.json()['groups']
-    groups_map = {group['name']: group['id'] for group in groups}
-
-    return {**channels_map, **groups_map}
+    return channels_map

--- a/slack_test.py
+++ b/slack_test.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.asyncio
 async def test_get_channels_info(mocker):
     """get_channels_info should obtain information for all public and private channels that doof knows about"""
     post_patch = mocker.async_patch('client_wrapper.ClientWrapper.post')
+    next_cursor = 'some cursor'
     post_patch.return_value.json.side_effect = [
         {
             'channels': [
@@ -22,6 +23,17 @@ async def test_get_channels_info(mocker):
                     'name': 'and a',
                     'id': 'private one',
                 },
+            ],
+            'response_metadata': {
+                'next_cursor': next_cursor,
+            }
+        },
+        {
+            'channels': [
+                {
+                    'name': 'two',
+                    'id': 'a channel in the next page'
+                }
             ]
         },
     ]
@@ -29,12 +41,22 @@ async def test_get_channels_info(mocker):
     assert await get_channels_info(token) == {
         'a': 'public channel',
         'and a': 'private one',
+        'two': 'a channel in the next page',
     }
-    post_patch.assert_called_once_with(
+    post_patch.assert_any_call(
         mocker.ANY,
         "https://slack.com/api/conversations.list",
         data={
             'token': token,
             "types": "public_channel,private_channel",
+        },
+    )
+    post_patch.assert_any_call(
+        mocker.ANY,
+        "https://slack.com/api/conversations.list",
+        data={
+            'token': token,
+            "types": "public_channel,private_channel",
+            "cursor": next_cursor,
         },
     )

--- a/slack_test.py
+++ b/slack_test.py
@@ -12,20 +12,29 @@ async def test_get_channels_info(mocker):
     """get_channels_info should obtain information for all public and private channels that doof knows about"""
     post_patch = mocker.async_patch('client_wrapper.ClientWrapper.post')
     post_patch.return_value.json.side_effect = [
-        {'channels': [{
-            'name': 'a',
-            'id': 'public channel',
-        }]},
-        {'groups': [{
-            'name': 'and a',
-            'id': 'private one',
-        }]},
+        {
+            'channels': [
+                {
+                    'name': 'a',
+                    'id': 'public channel',
+                },
+                {
+                    'name': 'and a',
+                    'id': 'private one',
+                },
+            ]
+        },
     ]
     token = 'token'
     assert await get_channels_info(token) == {
         'a': 'public channel',
         'and a': 'private one',
     }
-    post_patch.assert_any_call(mocker.ANY, "https://slack.com/api/channels.list", data={'token': token})
-    post_patch.assert_any_call(mocker.ANY, "https://slack.com/api/groups.list", data={'token': token})
-    assert post_patch.return_value.raise_for_status.call_count == 2
+    post_patch.assert_called_once_with(
+        mocker.ANY,
+        "https://slack.com/api/conversations.list",
+        data={
+            'token': token,
+            "types": "public_channel,private_channel",
+        },
+    )


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
The API doof is using is deprecated and some channels aren't showing up there anymore. There is a new API which should have the right information.

#### How should this be manually tested?
You should also be able to reproduce this by running `python3 bot_local.py micromasters-eng help`. On master you will see a `KeyError`, but on this PR you should see help text.
