### PR TITLE
Migrate to Slack's events API

### DIFF
--- a/bot_local.py
+++ b/bot_local.py
@@ -48,7 +48,7 @@ async def async_main():
     repos_info = load_repos_info(channels_info)
 
     bot = ConsoleBot(
-        websocket=None,
+        doof_id="console",
         slack_access_token=envs['SLACK_ACCESS_TOKEN'],
         github_access_token=envs['GITHUB_ACCESS_TOKEN'],
         timezone=envs['TIMEZONE'],

--- a/bot_local_test.py
+++ b/bot_local_test.py
@@ -1,0 +1,45 @@
+"""Make sure bot_local works"""
+import pytest
+
+from bot_local import async_main
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# pylint: disable=unused-argument
+async def test_bot_local(mocker, test_repo):
+    """
+    bot_local should execute a command
+    """
+    channel_name = "doof_channel"
+    channel_id = "D1234567"
+    timezone = "America/New_York"
+    slack_token = "slack token"
+    github_token = "github_token"
+    repos_info = [test_repo]
+    channels_info = {channel_name: channel_id}
+
+    get_envs_mock = mocker.patch('bot_local.get_envs', return_value={
+        "SLACK_ACCESS_TOKEN": slack_token,
+        "GITHUB_ACCESS_TOKEN": github_token,
+        "TIMEZONE": timezone
+    })
+    get_channels_info = mocker.async_patch('bot_local.get_channels_info', return_value=channels_info)
+    mocker.patch('bot_local.sys', argv=["bot_local.py", channel_name, "hi"])
+    load_repos = mocker.patch("bot_local.load_repos_info", return_value=repos_info)
+    handle_message_mock = mocker.async_patch('bot_local.ConsoleBot.handle_message')
+    startup_mock = mocker.async_patch('bot_local.ConsoleBot.startup')
+
+    await async_main()
+
+    get_envs_mock.assert_called_once_with()
+    load_repos.assert_called_once_with(channels_info)
+    get_channels_info.assert_called_once_with(slack_token)
+    startup_mock.assert_called_once_with(mocker.ANY)
+    handle_message_mock.assert_called_once_with(
+        mocker.ANY,
+        manager='mitodl_user',
+        channel_id=channel_id,
+        words=["hi"],
+    )

--- a/bot_test.py
+++ b/bot_test.py
@@ -2,7 +2,6 @@
 import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 
 import pytest
 import pytz
@@ -57,7 +56,7 @@ class DoofSpoof(Bot):
     def __init__(self, *, loop):
         """Since the testing bot isn't contacting slack or github we don't need these tokens here"""
         super().__init__(
-            websocket=Mock(),
+            doof_id="Doofenshmirtz",
             slack_access_token=SLACK_ACCESS,
             github_access_token=GITHUB_ACCESS,
             timezone=pytz.timezone("America/New_York"),
@@ -1226,3 +1225,24 @@ async def test_issue_release_notes(doof, test_repo, mocker):
     make_release_notes.assert_called_once_with(
         tups,
     )
+
+
+async def test_handle_event_message(doof):
+    """
+    Doof should handle messages appropriately
+    """
+    channel = "a channel"
+    await doof.handle_event(
+        webhook_dict={
+            "token": "token",
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel": channel,
+                "text": f"<@{doof.doof_id}> hi",
+                "user": "manager",
+            }
+        }
+    )
+
+    assert doof.said("hello!")

--- a/slack.py
+++ b/slack.py
@@ -32,3 +32,18 @@ async def get_channels_info(slack_access_token):
             break
 
     return {channel['name']: channel['id'] for channel in channels}
+
+
+async def get_doofs_id(slack_access_token):
+    """
+    Ask Slack for Doof's id
+
+    Args:
+        slack_access_token (str): The slack access token
+    """
+    client = ClientWrapper()
+    resp = await client.post("https://slack.com/api/users.identity", data={
+        "token": slack_access_token
+    })
+    resp.raise_for_status()
+    return resp.json()['user']['id']

--- a/slack_test.py
+++ b/slack_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 
-from slack import get_channels_info
+from slack import get_channels_info, get_doofs_id
 
 
 pytestmark = pytest.mark.asyncio
@@ -59,4 +59,21 @@ async def test_get_channels_info(mocker):
             "types": "public_channel,private_channel",
             "cursor": next_cursor,
         },
+    )
+
+
+async def test_get_doofs_id(mocker):
+    """get_doofs_id should contact the user API which gets slack info"""
+    post_patch = mocker.async_patch('client_wrapper.ClientWrapper.post')
+    doof_id = "It's doof"
+    token = "It's a token"
+    post_patch.return_value.json.return_value = {
+        "user": {
+            "id": doof_id
+        }
+    }
+    assert await get_doofs_id(token) == doof_id
+    post_patch.assert_called_once_with(
+        mocker.ANY,
+        "https://slack.com/api/users.identity", data={'token': token}
     )

--- a/web.py
+++ b/web.py
@@ -38,6 +38,45 @@ class ButtonHandler(RequestHandler):
         self.finish("")
 
 
+class EventHandler(RequestHandler):
+    """Handle events from Slack's events API"""
+
+    def initialize(self, token, bot):  # pylint: disable=arguments-differ
+        """
+        Set variables
+
+        Args:
+            token (str): The slack webhook token used to authenticate
+            bot (Bot): The bot
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.token = token
+        self.bot = bot
+
+    async def post(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """Handle webhook POST"""
+        arguments = json.loads(self.get_argument("payload"))  # pylint: disable=no-value-for-parameter
+        token = arguments['token']
+        if token != self.token:
+            # this is deprecated. At some point we should update:
+            # https://api.slack.com/authentication/verifying-requests-from-slack
+            self.set_status(401)
+            await self.finish("")
+            return
+
+        request_type = arguments["type"]
+        if request_type == "url_verification":
+            challenge = arguments["challenge"]
+            await self.finish(challenge)
+            return
+
+        self.bot.loop.create_task(
+            self.bot.handle_event(webhook_dict=arguments)
+        )
+
+        await self.finish("")
+
+
 def make_app(token, bot):
     """
     Create the application handling the webhook requests
@@ -54,4 +93,8 @@ def make_app(token, bot):
             'token': token,
             'bot': bot,
         }),
+        (r'/api/v0/events/', EventHandler, {
+            'token': token,
+            'bot': bot,
+        })
     ])

--- a/web_test.py
+++ b/web_test.py
@@ -32,15 +32,16 @@ class FinishReleaseTests(AsyncHTTPTestCase):
 
     def test_bad_auth(self):
         """
-        Bad auth tokens should be rejected
+        Bad auth tokens should be rejected for buttons
         """
-        response = self.fetch('/api/v0/buttons/', method='POST', body=urllib.parse.urlencode({
-            "payload": json.dumps({
-                "token": "xyz"
-            }),
-        }))
+        for url in ["/api/v0/buttons/", "/api/v0/events/"]:
+            response = self.fetch(url, method='POST', body=urllib.parse.urlencode({
+                "payload": json.dumps({
+                    "token": "xyz"
+                }),
+            }))
 
-        assert response.code == 401
+            assert response.code == 401
 
     def test_good_auth(self):
         """

--- a/web_test.py
+++ b/web_test.py
@@ -63,3 +63,46 @@ class FinishReleaseTests(AsyncHTTPTestCase):
         handle_webhook.assert_called_once_with(
             webhook_dict=payload,
         )
+
+    def test_event_challenge(self):
+        """Doof should respond to a challenge with the same challenge text"""
+        challenge = "event challenge text"
+        payload = {
+            "token": self.token,
+            "type": "url_verification",
+            "challenge": challenge
+        }
+
+        with patch('bot.Bot.handle_event') as handle_event:
+            async def fake_event(*args, **kwargs):  # pylint: disable=unused-argument
+                pass
+            handle_event.return_value = fake_event()  # pylint: disable=assignment-from-no-return
+
+            response = self.fetch('/api/v0/events/', method='POST', body=urllib.parse.urlencode({
+                "payload": json.dumps(payload),
+            }))
+
+        assert response.code == 200
+        assert response.body == challenge.encode()
+
+    def test_event_handle(self):
+        """Doof should call handle_event for valid events"""
+        payload = {
+            "token": self.token,
+            "type": "not_a_challenge",
+        }
+
+        with patch('bot.Bot.handle_event') as handle_event:
+            async def fake_event(*args, **kwargs):  # pylint: disable=unused-argument
+                pass
+            handle_event.return_value = fake_event()  # pylint: disable=assignment-from-no-return
+
+            response = self.fetch('/api/v0/events/', method='POST', body=urllib.parse.urlencode({
+                "payload": json.dumps(payload),
+            }))
+
+        assert response.code == 200
+        assert response.body == b""
+        handle_event.assert_called_once_with(
+            webhook_dict=payload,
+        )


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #246

#### What's this PR do?
Removes websocket code, and adds a endpoint to handle events POSTed to Doof's webserver, similar to the webhook API which already exists. 

#### How should this be manually tested?
This won't work at first. We need to deploy it, then slack will post a challenge and Doof should respond correctly. Then we can add permissions allowing receiving messages.
