### PR TITLE
Use users.list instead of users.identity

### DIFF
--- a/bot_test.py
+++ b/bot_test.py
@@ -317,7 +317,7 @@ async def test_release(doof, test_repo, mocker, command):
     assert doof.said("Now deploying to RC...")
     for channel_id in [test_repo.channel_id, ANNOUNCEMENTS_CHANNEL.channel_id]:
         assert doof.said(
-            "These people have commits in this release: {}".format(', '.join(authors)),
+            "These people have commits in this release: {}".format(', '.join(sorted(authors))),
             channel_id=channel_id,
         )
     assert wait_for_checkboxes_sync_mock.called is True

--- a/bot_test.py
+++ b/bot_test.py
@@ -317,9 +317,11 @@ async def test_release(doof, test_repo, mocker, command):
     assert doof.said("Now deploying to RC...")
     for channel_id in [test_repo.channel_id, ANNOUNCEMENTS_CHANNEL.channel_id]:
         assert doof.said(
-            "These people have commits in this release: {}".format(', '.join(sorted(authors))),
+            "These people have commits in this release",
             channel_id=channel_id,
         )
+        for author in authors:
+            assert doof.said(author, channel_id=channel_id)
     assert wait_for_checkboxes_sync_mock.called is True
 
 

--- a/slack.py
+++ b/slack.py
@@ -75,3 +75,5 @@ async def get_doofs_id(slack_access_token):
     ):
         if member['name'] == 'doof':
             return member['id']
+
+    raise Exception("Unable to find Doof's user id")


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #246 

#### What's this PR do?
Fix a permission issue. I think `users.identity` is restricted to an oauth workflow.

#### How should this be manually tested?
Run `python bot.py`. It shouldn't crash.