### PR TITLE
Remove typing indicator. It's not clear how to do this with the REST API

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -118,10 +118,7 @@ class Bot:
         self.loop = loop
         # Keep track of long running or scheduled tasks
         self.tasks = set()
-
-        # Used for only websocket messages
-        self.message_count = 0
-        self.doof_boot = now_in_utc()
+        self.boot = now_in_utc()
 
     async def lookup_users(self):
         """
@@ -278,20 +275,6 @@ class Bot:
             is_announcement=is_announcement,
             message_type=message_type,
         )
-
-    async def typing(self, channel_id):
-        """
-        Post a message in the Slack channel that Doof is typing something
-
-        Args:
-            channel_id (str): A channel id
-        """
-        await self.websocket.send(json.dumps({
-            "id": self.message_count,
-            "type": "typing",
-            "channel": channel_id,
-        }))
-        self.message_count += 1
 
     async def _library_release(self, command_args):
         """Do a library release"""
@@ -1131,7 +1114,6 @@ class Bot:
             channel_id (str): The channel id
             words (list of str): the words making up a command
         """
-        await self.typing(channel_id)
         for command in self.make_commands():
             command_words = command.command.split()
             if has_command(command_words, words):

--- a/bot_local.py
+++ b/bot_local.py
@@ -26,9 +26,6 @@ class ConsoleBot(Bot):
         )
         print("\033[92m{}\033[0m".format(line))
 
-    async def typing(self, channel_id):
-        """Ignore typing messages"""
-
 
 async def async_main():
     """Handle command line arguments and run a command"""

--- a/bot_test.py
+++ b/bot_test.py
@@ -81,9 +81,6 @@ class DoofSpoof(Bot):
         """Quick and dirty message recording"""
         self._append(channel_id, {"text": text, "attachments": attachments, "message_type": message_type})
 
-    async def typing(self, channel_id):
-        """Ignore typing"""
-
     async def update_message(self, *, channel_id, timestamp, text=None, attachments=None):
         """
         Record message updates
@@ -246,26 +243,6 @@ async def test_version(doof, test_repo, mocker):
         repo_url=test_repo.repo_url,
         commit_hash=a_hash,
     )
-
-
-async def test_typing(doof, test_repo, mocker):
-    """
-    Doof should signal typing before any arbitrary command
-    """
-    typing_sync = mocker.Mock()
-
-    async def typing_async(*args, **kwargs):
-        """Wrap sync method to allow mocking"""
-        typing_sync(*args, **kwargs)
-
-    mocker.patch.object(doof, 'typing', typing_async)
-    await doof.run_command(
-        manager='mitodl_user',
-        channel_id=test_repo.channel_id,
-        words=['hi'],
-    )
-    assert doof.said("hello!")
-    typing_sync.assert_called_once_with(test_repo.channel_id)
 
 
 # pylint: disable=too-many-locals

--- a/bot_test.py
+++ b/bot_test.py
@@ -360,9 +360,11 @@ async def test_hotfix_release(doof, test_repo, test_repo_directory, mocker):
     assert doof.said("Now deploying to RC...")
     for channel_id in [test_repo.channel_id, ANNOUNCEMENTS_CHANNEL.channel_id]:
         assert doof.said(
-            "These people have commits in this release: {}".format(', '.join(authors)),
+            "These people have commits in this release",
             channel_id=channel_id,
         )
+        for author in authors:
+            assert doof.said(author, channel_id=channel_id)
     assert wait_for_checkboxes_sync_mock.called is True
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 python-dateutil
 pytz
 requests
-websockets
 tornado
 virtualenv


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes a bug where `self.websocket` was still being referenced. The typing indicator code is removed because it's unclear how to do this in the REST API vs RTM.

#### How should this be manually tested?
N/A
