### PR TITLE
Migrate to secure signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ be all set.
   - `SLACK_ACCESS_TOKEN` - Used to communicate with Slack, for example to post a message or fetch the list of channels.
   - `BOT_ACCESS_TOKEN` - Used for Doof's communications as a Slack bot.
   - `GITHUB_ACCESS_TOKEN` - Used to access information about github repos and to create new pull requests.
-  - `SLACK_WEBHOOK_TOKEN` - Used to authenticate requests from Slack to Doof (ie the finish release button.)
+  - `SLACK_SECRET` - Used to authenticate requests from Slack to Doof (ie the finish release button, events API.)
   - `TIMEZONE` - The timezone of the team working with Doof
   - `PORT` - The port of the webserver, used for receiving webhooks from Slack
   - `PYPITEST_USERNAME` - The PyPI username to upload testing Python packages

--- a/app.json
+++ b/app.json
@@ -26,8 +26,8 @@
     "TIMEZONE": {
       "description": "The time zone of the team"
     },
-    "SLACK_WEBHOOK_TOKEN": {
-      "description": "The token used to authenticate requests to the webhook API"
+    "SLACK_SECRET": {
+      "description": "The secret to authenticate Slack requests to our APIs"
     }
   },
   "keywords": [

--- a/bot.py
+++ b/bot.py
@@ -79,7 +79,7 @@ def get_envs():
         'SLACK_ACCESS_TOKEN',
         'BOT_ACCESS_TOKEN',
         'GITHUB_ACCESS_TOKEN',
-        'SLACK_WEBHOOK_TOKEN',
+        'SLACK_SECRET',
         'TIMEZONE',
         'PORT',
         'PYPI_USERNAME',
@@ -1420,7 +1420,7 @@ async def async_main():
         loop=asyncio.get_event_loop(),
         doof_id=doof_id,
     )
-    app = make_app(token=envs['SLACK_WEBHOOK_TOKEN'], bot=bot)
+    app = make_app(secret=envs['SLACK_SECRET'], bot=bot)
     app.listen(port)
 
     await bot.startup()

--- a/web_test.py
+++ b/web_test.py
@@ -9,7 +9,7 @@ import pytest
 from tornado.testing import AsyncHTTPTestCase
 
 from bot_test import DoofSpoof
-from web import make_app
+from web import make_app, is_authenticated
 
 
 pytestmark = pytest.mark.asyncio
@@ -19,10 +19,10 @@ class FinishReleaseTests(AsyncHTTPTestCase):
     """Tests for the finish release button"""
 
     def setUp(self):
-        self.token = uuid.uuid4().hex
+        self.secret = uuid.uuid4().hex
         self.loop = asyncio.get_event_loop()
         self.doof = DoofSpoof(loop=self.loop)
-        self.app = make_app(self.token, self.doof)
+        self.app = make_app(secret=self.secret, bot=self.doof)
 
         super().setUp()
 
@@ -32,35 +32,31 @@ class FinishReleaseTests(AsyncHTTPTestCase):
 
     def test_bad_auth_buttons(self):
         """
-        Bad auth tokens should be rejected for buttons
+        Bad auth should be rejected for buttons
         """
-        response = self.fetch("/api/v0/buttons/", method='POST', body=urllib.parse.urlencode({
-            "payload": json.dumps({
-                "token": "xyz"
-            }),
-        }))
+        with patch("web.is_authenticated", return_value=False):
+            response = self.fetch("/api/v0/buttons/", method='POST', body=urllib.parse.urlencode({
+                "payload": json.dumps({}),
+            }))
 
         assert response.code == 401
 
     def test_bad_auth_events(self):
         """
-        Bad auth tokens should be rejected for buttons
+        Bad auth should be rejected for buttons
         """
-        response = self.fetch("/api/v0/events/", method='POST', body=json.dumps({
-            "token": "xyz"
-        }))
+        with patch("web.is_authenticated", return_value=False):
+            response = self.fetch("/api/v0/events/", method='POST', body=json.dumps({}))
 
-        assert response.code == 401
+            assert response.code == 401
 
     def test_good_auth(self):
         """
         If the token validates, we should call handle_webhook on Bot
         """
-        payload = {
-            "token": self.token
-        }
+        payload = {}
 
-        with patch('bot.Bot.handle_webhook') as handle_webhook:
+        with patch('bot.Bot.handle_webhook') as handle_webhook, patch("web.is_authenticated", return_value=True):
             async def fake_webhook(*args, **kwargs):  # pylint: disable=unused-argument
                 pass
             handle_webhook.return_value = fake_webhook()  # pylint: disable=assignment-from-no-return
@@ -78,12 +74,11 @@ class FinishReleaseTests(AsyncHTTPTestCase):
         """Doof should respond to a challenge with the same challenge text"""
         challenge = "event challenge text"
         payload = {
-            "token": self.token,
             "type": "url_verification",
             "challenge": challenge
         }
 
-        with patch('bot.Bot.handle_event') as handle_event:
+        with patch('bot.Bot.handle_event') as handle_event, patch("web.is_authenticated", return_value=True):
             async def fake_event(*args, **kwargs):  # pylint: disable=unused-argument
                 pass
             handle_event.return_value = fake_event()  # pylint: disable=assignment-from-no-return
@@ -96,11 +91,10 @@ class FinishReleaseTests(AsyncHTTPTestCase):
     def test_event_handle(self):
         """Doof should call handle_event for valid events"""
         payload = {
-            "token": self.token,
             "type": "not_a_challenge",
         }
 
-        with patch('bot.Bot.handle_event') as handle_event:
+        with patch('bot.Bot.handle_event') as handle_event, patch("web.is_authenticated", return_value=True):
             async def fake_event(*args, **kwargs):  # pylint: disable=unused-argument
                 pass
             handle_event.return_value = fake_event()  # pylint: disable=assignment-from-no-return
@@ -112,3 +106,31 @@ class FinishReleaseTests(AsyncHTTPTestCase):
         handle_event.assert_called_once_with(
             webhook_dict=payload,
         )
+
+
+# pylint: disable=too-many-arguments
+@pytest.mark.parametrize("secret, timestamp, signature, body, expected", [
+    [  # values from Slack docs
+        "8f742231b10e8888abcd99yyyzzz85a5",
+        "1531420618",
+        "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503",
+        b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&"
+        b"channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&"
+        b"text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%"
+        b"2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN"
+        b"&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c", True
+    ], [
+        "secret",
+        "timestamp",
+        "v0=notgonnawork",
+        b"body",
+        False
+    ]
+])
+def test_is_authenticated(mocker, secret, timestamp, signature, body, expected):
+    """Test our slack authentication logic"""
+    request = mocker.Mock(body=body, headers={
+        "X-Slack-Signature": signature,
+        "X-Slack-Request-Timestamp": timestamp,
+    })
+    assert is_authenticated(request, secret) is expected


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #248 

#### What's this PR do?
Switches to the hmac sha256 signature verification. The token currently being used is deprecated: https://api.slack.com/authentication/token-types#verification_tokens

#### How should this be manually tested?
Not really sure there's a good way to test this. The unit test uses parameters from the Slack docs to assert that our verification logic is correct: https://api.slack.com/authentication/verifying-requests-from-slack