### PR TITLE
Fix uptime command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -118,7 +118,7 @@ class Bot:
         self.loop = loop
         # Keep track of long running or scheduled tasks
         self.tasks = set()
-        self.boot = now_in_utc()
+        self.doof_boot = now_in_utc()
 
     async def lookup_users(self):
         """

--- a/bot_test.py
+++ b/bot_test.py
@@ -829,9 +829,7 @@ async def test_webhook_dismiss_release(doof):
 
 async def test_uptime(doof, mocker, test_repo):
     """Uptime should show how much time the bot has been awake"""
-    now = datetime(2015, 1, 1, 3, 4, 5, tzinfo=pytz.utc)
-    doof.doof_boot = now
-    later = now + timedelta(seconds=140)
+    later = doof.doof_boot + timedelta(seconds=140)
     mocker.patch('bot.now_in_utc', autospec=True, return_value=later)
     await doof.run_command(
         manager='mitodl_user',


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #254 

#### What's this PR do?
Fixes a typo introduced in a previous PR, and adjusts test to better detect that

#### How should this be manually tested?
Run `python bot_local.py micromasters-eng uptime`. It should not crash. You might see a "Directory not empty: hooks" error but that's unrelated and only appears on bot_local.py