### PR TITLE
Remove codecov checks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1420,8 +1420,8 @@ async def async_main():
     repos_info = load_repos_info(channels_info)
     try:
         port = int(envs['PORT'])
-    except ValueError:
-        raise Exception("PORT is invalid")
+    except ValueError as ex:
+        raise Exception("PORT is invalid") from ex
 
     bot = Bot(
         slack_access_token=envs['SLACK_ACCESS_TOKEN'],

--- a/bot_local.py
+++ b/bot_local.py
@@ -39,8 +39,8 @@ async def async_main():
     channels_info = await get_channels_info(envs['SLACK_ACCESS_TOKEN'])
     try:
         channel_id = channels_info[channel_name]
-    except KeyError:
-        raise Exception("Unable to find channel by name {}".format(channel_name))
+    except KeyError as ex:
+        raise Exception("Unable to find channel by name {}".format(channel_name)) from ex
 
     repos_info = load_repos_info(channels_info)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: no
+    patch:
+      default:
+        enabled: no
+    changes:
+      default:
+        enabled: no

--- a/finish_release.py
+++ b/finish_release.py
@@ -105,8 +105,8 @@ def main():
     """
     try:
         github_access_token = os.environ['GITHUB_ACCESS_TOKEN']
-    except KeyError:
-        raise Exception("Missing GITHUB_ACCESS_TOKEN")
+    except KeyError as ex:
+        raise Exception("Missing GITHUB_ACCESS_TOKEN") from ex
 
     parser = argparse.ArgumentParser()
     parser.add_argument("repo_url")

--- a/release.py
+++ b/release.py
@@ -270,8 +270,8 @@ async def release(github_access_token, repo_url, new_version, branch=None, commi
         if commit_hash:
             try:
                 await check_call(["git", "cherry-pick", commit_hash], cwd=working_dir)
-            except CalledProcessError:
-                raise ReleaseException(f"Cherry pick failed for the given hash {commit_hash}")
+            except CalledProcessError as ex:
+                raise ReleaseException(f"Cherry pick failed for the given hash {commit_hash}") from ex
         old_version = update_version(new_version, working_dir=working_dir)
         if parse_version(old_version) >= parse_version(new_version):
             raise ReleaseException("old version is {old} but the new version {new} is not newer".format(
@@ -302,8 +302,8 @@ def main():
     """
     try:
         github_access_token = os.environ['GITHUB_ACCESS_TOKEN']
-    except KeyError:
-        raise Exception("Missing GITHUB_ACCESS_TOKEN")
+    except KeyError as ex:
+        raise Exception("Missing GITHUB_ACCESS_TOKEN") from ex
     parser = argparse.ArgumentParser()
     parser.add_argument("repo_url")
     parser.add_argument("version")


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes the code coverage checks from github. Code coverage is still run and these checks should still be uploaded to codecov.io. This PR only removes the checks at the bottom of a PR.
