### PR TITLE
Add output content to error message for better debugging

### DIFF
--- a/async_subprocess.py
+++ b/async_subprocess.py
@@ -32,10 +32,10 @@ async def check_output(args, *, cwd, env=None, shell=False):
         env=env,
         cwd=cwd,
     )
-    stdout_data, _ = await proc.communicate(input=None)
+    stdout_data, stderr_data = await proc.communicate(input=None)
     returncode = await proc.wait()
     if returncode != 0:
-        raise AsyncCalledProcessError(returncode, popenargs[0], output=stdout_data)
+        raise AsyncCalledProcessError(returncode, popenargs[0], output=stdout_data, stderr=stderr_data)
     return stdout_data
 
 

--- a/async_subprocess.py
+++ b/async_subprocess.py
@@ -2,6 +2,8 @@
 import asyncio
 import subprocess
 
+from exception import AsyncCalledProcessError
+
 
 async def check_call(args, *, cwd, env=None, shell=False):
     """
@@ -11,7 +13,7 @@ async def check_call(args, *, cwd, env=None, shell=False):
     """
     returncode = await call(args, cwd=cwd, env=env, shell=shell)
     if returncode != 0:
-        raise subprocess.CalledProcessError(returncode, args[0])
+        raise AsyncCalledProcessError(returncode, args if shell else args[0])
 
 
 async def check_output(args, *, cwd, env=None, shell=False):
@@ -33,7 +35,7 @@ async def check_output(args, *, cwd, env=None, shell=False):
     stdout_data, _ = await proc.communicate(input=None)
     returncode = await proc.wait()
     if returncode != 0:
-        raise subprocess.CalledProcessError(returncode, args[0])
+        raise AsyncCalledProcessError(returncode, popenargs[0], output=stdout_data)
     return stdout_data
 
 

--- a/async_subprocess_test.py
+++ b/async_subprocess_test.py
@@ -4,6 +4,7 @@ import subprocess
 import pytest
 
 from async_subprocess import check_call, check_output, call
+from exception import AsyncCalledProcessError
 from test_util import async_wrapper
 
 
@@ -90,3 +91,15 @@ async def test_check_output_exec(mocker, is_success):
     else:
         with pytest.raises(subprocess.CalledProcessError):
             await check_output(args, shell=False, cwd=".")
+
+
+async def test_check_output_exception():
+    """Exceptions from check_output should include any text received"""
+    with pytest.raises(AsyncCalledProcessError) as ex:
+        await check_output("echo some text here && false", shell=True, cwd=".")
+
+    assert ex.value.returncode == 1
+    assert str(ex.value) == (
+        "Command 'echo some text here && false' returned non-zero exit status 1.."
+        " stdout=b'some text here\\n', stderr=None"
+    )

--- a/async_subprocess_test.py
+++ b/async_subprocess_test.py
@@ -93,13 +93,25 @@ async def test_check_output_exec(mocker, is_success):
             await check_output(args, shell=False, cwd=".")
 
 
-async def test_check_output_exception():
-    """Exceptions from check_output should include any text received"""
+async def test_check_output_exception_stdout():
+    """Exceptions from check_output should include any text received from stdout"""
     with pytest.raises(AsyncCalledProcessError) as ex:
         await check_output("echo some text here && false", shell=True, cwd=".")
 
     assert ex.value.returncode == 1
     assert str(ex.value) == (
         "Command 'echo some text here && false' returned non-zero exit status 1.."
-        " stdout=b'some text here\\n', stderr=None"
+        " stdout=b'some text here\\n', stderr=b''"
+    )
+
+
+async def test_check_output_exception_stderr():
+    """Exceptions from check_output should include any text received from stderr"""
+    with pytest.raises(AsyncCalledProcessError) as ex:
+        await check_output("1>&2 echo some text here && false", shell=True, cwd=".")
+
+    assert ex.value.returncode == 1
+    assert str(ex.value) == (
+        "Command '1>&2 echo some text here && false' returned non-zero exit status 1.."
+        " stdout=b'', stderr=b'some text here\\n'"
     )

--- a/exception.py
+++ b/exception.py
@@ -1,4 +1,5 @@
 """Exceptions for release script"""
+from subprocess import CalledProcessError
 
 
 class InputException(Exception):
@@ -23,3 +24,11 @@ class UpdateVersionException(Exception):
 
 class VersionMismatchException(Exception):
     """Error if the version is unexpected"""
+
+
+class AsyncCalledProcessError(CalledProcessError):
+    """Extend CalledProcessError to print the stdout as well"""
+
+    def __str__(self):
+        super_str = super().__str__()
+        return f"{super_str}. stdout={self.stdout}, stderr={self.stderr}"


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Right now, an exception will be raised when a command is executed, but we may not know what the output was which could be helpful in diagnosing the problem. This adds the output content to the error message when using `check_output` which already captures this information.

#### How should this be manually tested?
N/A
