### PR TITLE
Fix hugo support for releases

### DIFF
--- a/version.py
+++ b/version.py
@@ -9,6 +9,7 @@ import re
 from async_subprocess import check_output
 from constants import (
     DJANGO,
+    HUGO,
     LIBRARY_TYPE,
     NPM,
     SETUPTOOLS,
@@ -146,7 +147,8 @@ async def update_version(*, repo_info, new_version, working_dir):
     if repo_info.project_type == WEB_APPLICATION_TYPE:
         if repo_info.web_application_type == DJANGO:
             return update_python_version(new_version=new_version, working_dir=working_dir)
-        # do nothing for Hugo
+        elif repo_info.web_application_type == HUGO:
+            return await update_npm_version(new_version=new_version, working_dir=working_dir)
     elif repo_info.project_type == LIBRARY_TYPE:
         if repo_info.packaging_tool == SETUPTOOLS:
             return update_python_version(new_version=new_version, working_dir=working_dir)

--- a/version_test.py
+++ b/version_test.py
@@ -194,7 +194,7 @@ async def test_update_npm_version():
 # pylint: disable=too-many-arguments
 @pytest.mark.parametrize("project_type, packaging_tool, web_application_type, expected_python, expected_js", [
     [WEB_APPLICATION_TYPE, None, DJANGO, True, False],
-    [WEB_APPLICATION_TYPE, None, HUGO, False, False],
+    [WEB_APPLICATION_TYPE, None, HUGO, False, True],
     [LIBRARY_TYPE, SETUPTOOLS, None, True, False],
     [LIBRARY_TYPE, NPM, None, False, True],
 ])


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #265 

#### What's this PR do?
The hugo-course-publisher version is stored in the package.json file so we need to update the version there

#### How should this be manually tested?
N/A. We can run `release notes` on the hugo-course-publisher channel after this merges
