### PR TITLE
Add finish release button for library releases, and other similar features

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -287,16 +287,22 @@ class Bot:
         repo_info = command_args.repo_info
         version = command_args.args[0]
         channel_id = repo_info.channel_id
+        org, repo = get_org_and_repo(repo_info.repo_url)
 
         await release(
             github_access_token=self.github_access_token,
             repo_info=repo_info,
             new_version=version,
         )
+        pr = await get_release_pr(
+            github_access_token=self.github_access_token,
+            org=org,
+            repo=repo,
+        )
         await self.say(
             channel_id=channel_id,
             text=(
-                f"Behold, my new evil scheme - release {version} for {repo_info.name}! Tests are running on Travis. "
+                f"Behold, my new evil scheme - release {version} for {repo_info.name}! PR is up at {pr.url}. Tests are running on Travis. "
                 f"Once the tests succeed, finish the release."
             ),
             attachments=[

--- a/bot.py
+++ b/bot.py
@@ -288,10 +288,6 @@ class Bot:
         version = command_args.args[0]
         channel_id = repo_info.channel_id
 
-        await self.say(
-            channel_id=channel_id,
-            text=f"Merging evil scheme {version} for {repo_info.name}...",
-        )
         await release(
             github_access_token=self.github_access_token,
             repo_info=repo_info,
@@ -300,8 +296,8 @@ class Bot:
         await self.say(
             channel_id=channel_id,
             text=(
-                f"My evil scheme {version} for {repo_info.name} has been released! "
-                f"Once Travis succeeds, finish the release."
+                f"Behold, my new evil scheme - release {version} for {repo_info.name}! Tests are running on Travis. "
+                f"Once the tests succeed, finish the release."
             )
         )
 

--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,8 @@ from lib import (
     next_workday_at_10,
     parse_date,
     VERSION_RE,
-    COMMIT_HASH_RE
+    COMMIT_HASH_RE,
+    remove_path_from_url,
 )
 from publish import publish
 from slack import get_channels_info, get_doofs_id
@@ -412,10 +413,11 @@ class Bot:
             org=org,
             repo=repo,
         )
+        rc_server = remove_path_from_url(repo_info.rc_hash_url)
         await self.say(
             channel_id=channel_id,
             text=(
-                f"Release {pr.version} for {repo_info.name} was deployed! PR is up at {pr.url}."
+                f"Release {pr.version} for {repo_info.name} was deployed at {rc_server}! PR is up at {pr.url}."
                 f" These people have commits in this release: {', '.join(slack_usernames)}"
             ),
             is_announcement=True
@@ -439,10 +441,11 @@ class Bot:
             hash_url=repo_info.prod_hash_url,
             watch_branch="release",
         )
+        prod_server = remove_path_from_url(repo_info.prod_hash_url)
         await self.say(
             channel_id=channel_id,
             text=(
-                f"My evil scheme {version} for {repo_info.name} has been released to production. "
+                f"My evil scheme {version} for {repo_info.name} has been released to production at {prod_server}. "
                 "And by 'released', I mean completely...um...leased."
             ),
             is_announcement=True,

--- a/bot.py
+++ b/bot.py
@@ -298,7 +298,25 @@ class Bot:
             text=(
                 f"Behold, my new evil scheme - release {version} for {repo_info.name}! Tests are running on Travis. "
                 f"Once the tests succeed, finish the release."
-            )
+            ),
+            attachments=[
+                {
+                    "fallback": "Finish the release",
+                    "callback_id": FINISH_RELEASE_ID,
+                    "actions": [
+                        {
+                            "name": "finish_release",
+                            "text": "Finish the release",
+                            "type": "button",
+                            "confirm": {
+                                "title": "Are you sure?",
+                                "ok_text": "Finish the release",
+                                "dismiss_text": "Cancel",
+                            }
+                        }
+                    ]
+                }
+            ]
         )
 
     async def _web_application_release(self, command_args, hotfix_version=None):

--- a/bot_test.py
+++ b/bot_test.py
@@ -464,7 +464,22 @@ async def test_release_library(doof, library_test_repo, mocker):
     )
     assert doof.said(
         f"Behold, my new evil scheme - release {pr.version} for {library_test_repo.name}! Tests are running on Travis. "
-        f"Once the tests succeed, finish the release."
+        f"Once the tests succeed, finish the release.",
+        attachments=[
+            {
+                'actions': [
+                    {
+                        'name': 'finish_release', 'text': 'Finish the release', 'type': 'button',
+                        "confirm": {
+                            "title": "Are you sure?",
+                            "ok_text": "Finish the release",
+                            "dismiss_text": "Cancel",
+                        }
+                    },
+                ],
+                'callback_id': 'finish_release', 'fallback': 'Finish the release'
+            }
+        ]
     )
 
 

--- a/bot_test.py
+++ b/bot_test.py
@@ -457,13 +457,13 @@ async def test_release_library(doof, library_test_repo, mocker):
         repo_info=library_test_repo,
         new_version=pr.version,
     )
-    get_release_pr_mock.assert_called_once_with(
+    get_release_pr_mock.assert_any_call(
         github_access_token=GITHUB_ACCESS,
         org=org,
         repo=repo,
     )
     assert doof.said(
-        f"Behold, my new evil scheme - release {pr.version} for {library_test_repo.name}! Tests are running on Travis. "
+        f"Behold, my new evil scheme - release {pr.version} for {library_test_repo.name}! PR is up at {pr.url}. Tests are running on Travis. "
         f"Once the tests succeed, finish the release.",
         attachments=[
             {

--- a/bot_test.py
+++ b/bot_test.py
@@ -463,11 +463,8 @@ async def test_release_library(doof, library_test_repo, mocker):
         repo=repo,
     )
     assert doof.said(
-        f"Merging evil scheme {pr.version} for {library_test_repo.name}..."
-    )
-    assert doof.said(
-        f"My evil scheme {pr.version} for {library_test_repo.name} has been released! "
-        f"Once Travis succeeds, finish the release."
+        f"Behold, my new evil scheme - release {pr.version} for {library_test_repo.name}! Tests are running on Travis. "
+        f"Once the tests succeed, finish the release."
     )
 
 

--- a/lib.py
+++ b/lib.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 from tempfile import TemporaryDirectory
+from urllib.parse import urlparse, urlunparse
 
 from dateutil.parser import parse
 
@@ -359,3 +360,22 @@ async def init_working_dir(github_access_token, repo_url, *, branch=None):
         await check_call(["git", "checkout", branch, "-q"], cwd=directory)
 
         yield directory
+
+
+def remove_path_from_url(url):
+    """
+    Remove everything after the path from the URL.
+
+    Args:
+        url (str): The URL
+
+    Returns:
+        str:
+            The URL without a path.
+            For example https://example:1234/a/path/?query=param#fragment would become
+            https://example:1234/
+    """
+    parsed = urlparse(url)
+    # The docs recommend _replace: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse
+    updated = parsed._replace(path="", query="", fragment="")
+    return urlunparse(updated)

--- a/lib_test.py
+++ b/lib_test.py
@@ -16,6 +16,7 @@ from lib import (
     parse_checkmarks,
     reformatted_full_name,
     ReleasePR,
+    remove_path_from_url,
     url_with_access_token,
 )
 from repo_info import RepoInfo
@@ -291,3 +292,13 @@ async def test_async_patch(mocker):
     mocked.return_value = 123
     assert await call(["ls"], cwd="/") == 123
     assert await call(["ls"], cwd="/") == 123
+
+
+@pytest.mark.parametrize("url,expected", [
+    ["https://www.example.com", "https://www.example.com"],
+    ["http://mit.edu/a/path", "http://mit.edu"],
+    ["http://example.com:5678/?query=params#included", "http://example.com:5678"]
+])
+def test_remove_path_from_url(url, expected):
+    """remove_path_from_url should only keep the scheme, port, and host parts of the URL"""
+    assert remove_path_from_url(url) == expected


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #236 
Fixes #243 
Fixes #268 
Fixes #272 

#### What's this PR do?
 - Adds a merge button to finish a release similar to web application releases
 - Adds a link to the release PR for library projects
 - Fix text to say that the release is in progress
 - Output link to server for RC and production when a deployment happens

#### How should this be manually tested?
Probably easiest just to merge then do a library release to verify this
