### PR TITLE
Update heroku python version to 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 sudo: required  # for python 3.7, may not be needed in future
 dist: xenial  # for python 3.7
 python:
-  - "3.7"
+  - "3.9"
 node_js:
-  - "6.2"
+  - "12"
 install:
  - pip install -r test_requirements.txt
  - npm install

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.0
+python-3.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py39
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #281 

#### What's this PR do?
Updates python to 3.9 since the new heroku buildpack does not support 3.7. I updated tox and travis as well, though we need to switch to github actions at some point soon so these changes are temporary #282 

#### How should this be manually tested?
N/A