### PR TITLE
Preserve indentation when updating version

### DIFF
--- a/version.py
+++ b/version.py
@@ -77,26 +77,30 @@ def update_python_version_in_file(*, root, filename, new_version):
             updated_line = line
 
             if filename == "settings.py":
-                regex = r"^VERSION = .*(?P<version>{}).*$".format(VERSION_RE)
+                regex = fr"^VERSION = .*(?P<version>{VERSION_RE}).*$"
                 match = re.match(regex, line)
                 if match:
                     update_count += 1
                     old_version = match.group('version').strip()
-                    updated_line = re.sub(regex, "VERSION = \"{}\"".format(new_version), line)
+                    updated_line = re.sub(regex, f"VERSION = \"{new_version}\"", line)
             elif filename == "__init__.py":
-                regex = r"^__version__ ?=.*(?P<version>{}).*".format(VERSION_RE)
+                regex = fr"^__version__ ?=.*(?P<version>{VERSION_RE}).*"
                 match = re.match(regex, line)
                 if match:
                     update_count += 1
                     old_version = match.group('version').strip()
-                    updated_line = re.sub(regex, "__version__ = '{}'".format(new_version), line)
+                    updated_line = re.sub(regex, f"__version__ = \"{new_version}\"", line)
             elif filename == "setup.py":
-                regex = r"\s*version=.*(?P<version>{}).*".format(VERSION_RE)
+                regex = fr"(?P<spaces>\s*)version=(?P<quote>.*)(?P<version>{VERSION_RE})(?P<after>.*)"
                 match = re.match(regex, line)
                 if match:
                     update_count += 1
                     old_version = match.group('version').strip()
-                    updated_line = re.sub(regex, "version='{}',".format(new_version), line)
+                    updated_line = re.sub(
+                        regex,
+                        f"{match.group('spaces')}version={match.group('quote')}{new_version}{match.group('after')}",
+                        line,
+                    )
 
             file_lines.append("{}\n".format(updated_line))
 

--- a/version_test.py
+++ b/version_test.py
@@ -62,16 +62,17 @@ async def test_update_python_version_settings(test_repo, test_repo_directory):
 async def test_update_python_version_init(test_repo_directory, test_repo):
     """If we detect a version in a __init__.py file we should update it properly"""
     old_version = '1.2.3'
-    os.unlink(os.path.join(test_repo_directory, "ccxcon/settings.py"))
-    with open(os.path.join(test_repo_directory, "ccxcon/__init__.py"), "w") as f:
+    test_repo_directory = Path(test_repo_directory)
+    os.unlink(test_repo_directory / "ccxcon" / "settings.py")
+    with open(test_repo_directory / "ccxcon" / "__init__.py", "w") as f:
         f.write("__version__ = '{}'".format(old_version))
     new_version = "4.5.6"
     assert await update_version(repo_info=test_repo, new_version=new_version, working_dir=test_repo_directory) == old_version
 
     found_new_version = False
-    with open(os.path.join(test_repo_directory, "ccxcon/__init__.py")) as f:
+    with open(test_repo_directory / "ccxcon" / "__init__.py") as f:
         for line in f.readlines():
-            if line.strip() == "__version__ = '{}'".format(new_version):
+            if line.strip() == f'__version__ = "{new_version}"':
                 found_new_version = True
                 break
     assert found_new_version, "Unable to find updated version"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-data-parser/pull/109

#### What's this PR do?
Preserves indentation so updating the version string doesn't break reformatting
