### PR TITLE
Add support for other default branches like 'main'

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -45,6 +45,7 @@ from release import (
     release,
 )
 from lib import (
+    get_default_branch,
     get_release_pr,
     get_unchecked_authors,
     format_user_id,
@@ -744,12 +745,13 @@ class Bot:
         """
         repo_info = command_args.repo_info
         async with init_working_dir(self.github_access_token, repo_info.repo_url) as working_dir:
+            default_branch = await get_default_branch(working_dir)
             last_version = await update_version(repo_info=repo_info, new_version="9.9.9", working_dir=working_dir)
 
             release_notes = await create_release_notes(
-                last_version, with_checkboxes=False, base_branch="master", root=working_dir
+                last_version, with_checkboxes=False, base_branch=default_branch, root=working_dir
             )
-            has_new_commits = await any_new_commits(last_version, base_branch="master", root=working_dir)
+            has_new_commits = await any_new_commits(last_version, base_branch=default_branch, root=working_dir)
 
         await self.say_with_attachment(
             channel_id=repo_info.channel_id,

--- a/finish_release.py
+++ b/finish_release.py
@@ -8,6 +8,7 @@ from async_subprocess import (
     check_output,
 )
 from exception import VersionMismatchException
+from lib import get_default_branch
 from release import (
     init_working_dir,
     validate_dependencies,
@@ -75,7 +76,9 @@ async def set_release_date(version, timezone, *, root):
 
 async def merge_release(*, root):
     """Merge release to master"""
-    await check_call(['git', 'checkout', '-q', 'master'], cwd=root)
+    default_branch = await get_default_branch(root)
+
+    await check_call(['git', 'checkout', '-q', default_branch], cwd=root)
     await check_call(['git', 'pull'], cwd=root)
     await check_call(['git', 'merge', 'release', '--no-edit'], cwd=root)
     await check_call(['git', 'push'], cwd=root)

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -51,12 +51,15 @@ async def test_merge_release_candidate(mocker):
 async def test_merge_release(mocker):
     """merge_release should merge the release and push it to origin"""
     patched_check_call = mocker.async_patch('finish_release.check_call')
+    branch = "a_branch"
+    default_branch_mock = mocker.async_patch('finish_release.get_default_branch', return_value=branch)
     root = "/a/bad/directory/path"
     await merge_release(root=root)
-    patched_check_call.assert_any_call(['git', 'checkout', '-q', 'master'], cwd=root)
+    patched_check_call.assert_any_call(['git', 'checkout', '-q', branch], cwd=root)
     patched_check_call.assert_any_call(['git', 'pull'], cwd=root)
     patched_check_call.assert_any_call(['git', 'merge', 'release', '--no-edit'], cwd=root)
     patched_check_call.assert_any_call(['git', 'push'], cwd=root)
+    default_branch_mock.assert_called_once_with(root)
 
 
 async def test_tag_release(mocker, test_repo_directory):

--- a/lib_test.py
+++ b/lib_test.py
@@ -7,6 +7,7 @@ import pytest
 from constants import DJANGO, WEB_APPLICATION_TYPE
 from github import github_auth_headers
 from lib import (
+    get_default_branch,
     get_release_pr,
     get_unchecked_authors,
     load_repos_info,
@@ -322,3 +323,10 @@ def test_parse_text_matching_options_error():
     with pytest.raises(Exception) as ex:
         parse_text_matching_options(["abc", "xyz"])("def")
     assert ex.value.args[0] == "Unexpected option def. Valid options: abc, xyz"
+
+
+async def test_get_default_branch(test_repo_directory):
+    """
+    get_default_branch should get master or main, depending on the default branch in the repository
+    """
+    assert await get_default_branch(test_repo_directory) == "master"

--- a/release_test.py
+++ b/release_test.py
@@ -81,6 +81,8 @@ async def test_init_working_dir(mocker, branch):
     repo_url = "https://github.com/mitodl/release-script.git"
     access_token = 'fake_access_token'
     check_call_mock = mocker.async_patch('lib.check_call')
+    default_branch = "a_branch"
+    mocker.async_patch('lib.get_default_branch', return_value=default_branch)
     async with init_working_dir(
             access_token, repo_url, branch=branch,
     ) as other_directory:
@@ -93,7 +95,7 @@ async def test_init_working_dir(mocker, branch):
         ['git', 'config', 'push.default', 'simple'],
         ['git', 'remote', 'add', 'origin', url_with_access_token(access_token, repo_url)],
         ['git', 'fetch', '--tags', '-q'],
-        ['git', 'checkout', "master" if branch is None else branch, '-q'],
+        ['git', 'checkout', default_branch if branch is None else branch, '-q'],
     ]
 
 

--- a/test_util.py
+++ b/test_util.py
@@ -48,6 +48,10 @@ def make_test_repo():
 
                 sync_check_call(["git", "fast-import", "--quiet"], stdin=temp_file, cwd=directory)
         sync_check_call(["git", "checkout", "--quiet", "master"], cwd=directory)
+        sync_check_call(
+            ["git", "remote", "add", "origin", "https://github.com/mitodl/release-script.git"],
+            cwd=directory,
+        )
         yield Path(directory)
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #290 

#### What's this PR do?
Reads the default branch from a repository and uses that instead of `master`
