### PR TITLE
Support updating go.mod file of related repo after release

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -635,7 +635,6 @@ class Bot:
             is_announcement=True,
         )
 
-
     async def finish_release(self, command_args):
         """
         Merge the release candidate into the release branch, tag it, merge to master, and wait for deployment
@@ -660,7 +659,8 @@ class Bot:
             github_access_token=self.github_access_token,
             repo_url=repo_url,
             version=version,
-            timezone=self.timezone
+            timezone=self.timezone,
+            go_mod_repo_info=repo_info.go_mod_repo_info,
         )
 
         if repo_info.project_type == WEB_APPLICATION_TYPE:

--- a/bot_test.py
+++ b/bot_test.py
@@ -549,7 +549,8 @@ async def test_finish_release(doof, mocker, project_type):
         github_access_token=GITHUB_ACCESS,
         repo_url=test_repo.repo_url,
         version=version,
-        timezone=doof.timezone
+        timezone=doof.timezone,
+        go_mod_repo_info=None,
     )
     assert doof.said(f"Merged evil scheme {version} for {test_repo.name}!")
     if project_type == WEB_APPLICATION_TYPE:
@@ -676,7 +677,8 @@ async def test_webhook_finish_release(doof, mocker):
         github_access_token=doof.github_access_token,
         repo_url=repo_url,
         version=pr_body.version,
-        timezone=doof.timezone
+        timezone=doof.timezone,
+        go_mod_repo_info=None,
     )
     assert doof.said("Merging...")
     assert not doof.said("Error")

--- a/conftest.py
+++ b/conftest.py
@@ -52,6 +52,7 @@ WEB_TEST_REPO_INFO = RepoInfo(
     web_application_type=DJANGO,
     packaging_tool=None,
     announcements=False,
+    go_mod_repo_info=None,
 )
 
 
@@ -80,6 +81,7 @@ LIBRARY_TEST_REPO_INFO = RepoInfo(
     packaging_tool=SETUPTOOLS,
     web_application_type=None,
     announcements=False,
+    go_mod_repo_info=None,
 )
 NPM_TEST_REPO_INFO = RepoInfo(
     name='node_doof',
@@ -92,6 +94,7 @@ NPM_TEST_REPO_INFO = RepoInfo(
     packaging_tool=NPM,
     web_application_type=None,
     announcements=False,
+    go_mod_repo_info=None,
 )
 ANNOUNCEMENTS_CHANNEL = RepoInfo(
     name='doof_repo',
@@ -104,13 +107,21 @@ ANNOUNCEMENTS_CHANNEL = RepoInfo(
     web_application_type=None,
     packaging_tool=None,
     announcements=True,
+    go_mod_repo_info=None,
 )
 
 
 @pytest.fixture
-def library_test_repo(test_repo_directory):
+def library_test_repo_directory():
+    """Directory created for testing with library_test_repo"""
+    with make_test_repo() as working_dir:
+        yield working_dir
+
+
+@pytest.fixture
+def library_test_repo(library_test_repo_directory):
     """Initialize the library test repo from the gzipped file"""
-    with open(os.path.join(test_repo_directory, "setup.py"), "w") as f:
+    with open(os.path.join(library_test_repo_directory, "setup.py"), "w") as f:
         # Hacky way to convert a web application project to a library
         f.write(SETUP_PY)
 

--- a/lib.py
+++ b/lib.py
@@ -337,7 +337,18 @@ def load_repos_info(channel_lookup):
             web_application_type=repo_info.get('web_application_type'),
             packaging_tool=repo_info.get('packaging_tool'),
             announcements=repo_info.get('announcements'),
+            go_mod_repo_info=None,
         ) for repo_info in repos_info['repos']
+    ]
+
+    repo_dict_lookup = {info["name"]: info for info in repos_info["repos"]}
+    repo_info_lookup = {info.name: info for info in infos}
+
+    infos = [
+        RepoInfo(
+            **{k: v for k, v in info._asdict().items() if k != "go_mod_repo_info"},
+            go_mod_repo_info=repo_info_lookup.get(repo_dict_lookup[info.name].get("go_mod")),
+        ) for info in infos
     ]
 
     # some basic validation for sanity checking

--- a/lib_test.py
+++ b/lib_test.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 from requests import Response, HTTPError
 import pytest
 
-from constants import DJANGO, WEB_APPLICATION_TYPE
+from constants import (
+    DJANGO,
+    LIBRARY_TYPE,
+    NPM,
+    WEB_APPLICATION_TYPE,
+)
 from github import github_auth_headers
 from lib import (
     get_default_branch,
@@ -254,24 +259,50 @@ async def test_load_repos_info(mocker):
                 "web_application_type": DJANGO,
                 "announcements": False,
             },
+            {
+                "name": "bootcamp-ecommerce-library",
+                "repo_url": "https://github.com/mitodl/bootcamp-ecommerce-library.git",
+                "channel_name": "bootcamp-library",
+                "project_type": LIBRARY_TYPE,
+                "packaging_tool": NPM,
+                "announcements": False,
+                "go_mod": "bootcamp-ecommerce"
+            },
         ]
     })
 
+    expected_web_application = RepoInfo(
+        name='bootcamp-ecommerce',
+        repo_url='https://github.com/mitodl/bootcamp-ecommerce.git',
+        ci_hash_url="https://bootcamp-ecommerce-ci.herokuapp.com/static/hash.txt",
+        rc_hash_url="https://bootcamp-ecommerce-rc.herokuapp.com/static/hash.txt",
+        prod_hash_url="https://bootcamp-ecommerce.herokuapp.com/static/hash.txt",
+        channel_id='bootcamp_channel_id',
+        project_type=WEB_APPLICATION_TYPE,
+        web_application_type=DJANGO,
+        packaging_tool=None,
+        announcements=False,
+        go_mod_repo_info=None,
+    )
+    expected_library = RepoInfo(
+        name='bootcamp-ecommerce-library',
+        repo_url='https://github.com/mitodl/bootcamp-ecommerce-library.git',
+        ci_hash_url=None,
+        rc_hash_url=None,
+        prod_hash_url=None,
+        channel_id='bootcamp_library_channel_id',
+        project_type=LIBRARY_TYPE,
+        web_application_type=None,
+        packaging_tool=NPM,
+        announcements=False,
+        go_mod_repo_info=expected_web_application,
+    )
+
     assert load_repos_info({
-        'bootcamp-eng': 'bootcamp_channel_id'
+        'bootcamp-eng': 'bootcamp_channel_id',
+        'bootcamp-library': 'bootcamp_library_channel_id',
     }) == [
-        RepoInfo(
-            name='bootcamp-ecommerce',
-            repo_url='https://github.com/mitodl/bootcamp-ecommerce.git',
-            ci_hash_url="https://bootcamp-ecommerce-ci.herokuapp.com/static/hash.txt",
-            rc_hash_url="https://bootcamp-ecommerce-rc.herokuapp.com/static/hash.txt",
-            prod_hash_url="https://bootcamp-ecommerce.herokuapp.com/static/hash.txt",
-            channel_id='bootcamp_channel_id',
-            project_type=WEB_APPLICATION_TYPE,
-            web_application_type=DJANGO,
-            packaging_tool=None,
-            announcements=False,
-        ),
+        expected_web_application, expected_library
     ]
     assert json_load.call_count == 1
 

--- a/publish_test.py
+++ b/publish_test.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.asyncio
 
 
 # pylint: disable=unused-argument
-async def test_upload_with_twine(mocker, test_repo_directory, library_test_repo):
+async def test_upload_with_twine(mocker, library_test_repo, library_test_repo_directory):
     """upload_with_twine should create a dist based on a version and upload to pypi or pypitest"""
 
     twine_env = {
@@ -37,7 +37,7 @@ async def test_upload_with_twine(mocker, test_repo_directory, library_test_repo)
         if not command[0].endswith("twine"):
             return subprocess.call(command, *args, **kwargs)
 
-        assert kwargs['cwd'] == test_repo_directory
+        assert kwargs['cwd'] == library_test_repo_directory
         env = kwargs['env']
         assert env['TWINE_USERNAME'] == twine_env['PYPI_USERNAME']
         assert env['TWINE_PASSWORD'] == twine_env['PYPI_PASSWORD']
@@ -49,7 +49,7 @@ async def test_upload_with_twine(mocker, test_repo_directory, library_test_repo)
     async with virtualenv("python3", os.environ) as (virtualenv_dir, environ):
         call_mock = mocker.async_patch('async_subprocess.call', side_effect=_call)
         await upload_with_twine(
-            project_dir=test_repo_directory, virtualenv_dir=virtualenv_dir, environ=environ
+            project_dir=library_test_repo_directory, virtualenv_dir=virtualenv_dir, environ=environ
         )
     assert call_mock.call_count == 1
 

--- a/repo_info.py
+++ b/repo_info.py
@@ -12,4 +12,5 @@ RepoInfo = namedtuple('RepoInfo', [
     'web_application_type',
     'packaging_tool',
     'announcements',
+    'go_mod_repo_info',
 ])

--- a/repos_info.json
+++ b/repos_info.json
@@ -160,7 +160,8 @@
       "channel_name": "ocw-course-hugo-theme",
       "project_type": "library",
       "packaging_tool": "npm",
-      "announcements": false
+      "announcements": false,
+      "go_mod": "ocw-course-hugo-starter"
     }
   ]
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #293 

#### What's this PR do?
This adds a parameter so that when one project is released, another project's `go.mod` file can be updated to point to that release. This is means that when [ocw-course-hugo-theme](https://github.com/mitodl/ocw-course-hugo-theme) has a new release, [ocw-course-hugo-starter](https://github.com/mitodl/ocw-course-hugo-starter) is updated at the same time. Note that there's no pull request here, the commit is made directly to `main`.