### PR TITLE
Remove git string which is unnecessary, and make ocw-course-hugo-starter a web application project

### DIFF
--- a/finish_release.py
+++ b/finish_release.py
@@ -86,13 +86,12 @@ async def merge_release(*, root):
     await check_call(['git', 'push'], cwd=root)
 
 
-def update_go_mod(*, path, git_string, version, repo_url):
+def update_go_mod(*, path, version, repo_url):
     """
     Update go.mod, replacing the original git tag with our own copy
 
     Args:
         path (str or Path): The path to the go.mod file
-        git_string (str): The git hash and date referring to the commit for the module
         version (str): The new version for the referenced go module
         repo_url (str): The URL for the repository
 
@@ -105,7 +104,7 @@ def update_go_mod(*, path, git_string, version, repo_url):
 
     lines = [
         (
-            f"require github.com/{org}/{repo} v{version}-{git_string} // indirect\n"
+            f"require github.com/{org}/{repo} v{version} // indirect\n"
             if line.startswith("require ") else line
         ) for line in old_lines
     ]
@@ -117,30 +116,21 @@ def update_go_mod(*, path, git_string, version, repo_url):
     return False
 
 
-async def update_go_mod_and_commit(*, github_access_token, new_version, release_path, go_mod_repo_info):
+async def update_go_mod_and_commit(*, github_access_token, new_version, go_mod_repo_info):
     """
     Create a new PR with an updated go.mod file
 
     Args:
         github_access_token (str): A token to access github APIs
         new_version (str): The new version of the finished release
-        release_path (str or Path): The path to the project which is being released
         go_mod_repo_info (RepoInfo): The repository information of the linked repository
     """
     go_mod_repo_url = go_mod_repo_info.repo_url
     go_mod_name = go_mod_repo_info.name
     async with init_working_dir(github_access_token, go_mod_repo_url) as go_mod_repo_path:
         go_mod_repo_path = Path(go_mod_repo_path)
-        git_string = await check_output(
-            [
-                "git", "--no-pager", "show", "--quiet", "--abbrev=12",
-                "--date='format-local:%Y%m%d%H%M%S'", '--format="%cd-%h"',
-            ],
-            cwd=release_path,
-        )
         changed = update_go_mod(
             path=go_mod_repo_path / "go.mod",
-            git_string=git_string,
             version=new_version,
             repo_url=go_mod_repo_url,
         )
@@ -171,7 +161,6 @@ async def finish_release(*, github_access_token, repo_url, version, timezone, go
         if go_mod_repo_info:
             await update_go_mod_and_commit(
                 github_access_token=github_access_token,
-                release_path=working_dir,
                 new_version=version,
                 go_mod_repo_info=go_mod_repo_info,
             )

--- a/repos_info.json
+++ b/repos_info.json
@@ -150,8 +150,11 @@
       "name": "ocw-course-hugo-starter",
       "repo_url": "https://github.com/mitodl/ocw-course-hugo-starter.git",
       "channel_name": "ocw-course-hugo-starter",
-      "project_type": "library",
-      "packaging_tool": "npm",
+      "project_type": "web_application",
+      "web_application_type": "hugo",
+      "ci_hash_url": "https://ocw-www--ocw-next.netlify.app/static/hash.txt",
+      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/hash.txt",
       "announcements": false
     },
     {


### PR DESCRIPTION

#### What are the relevant tickets?
Related to #294 

#### What's this PR do?
 - Instead of writing the version and the git string with the date and hash, this just writes out the version. This removes a bug where the git command was confused by the date string syntax being used.
 - Make ocw-course-hugo-starter a web application project similar to ocw-www because both trigger the same builds
