### PR TITLE
Treat ocw-course-hugo-starter as a library application for now

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -150,11 +150,8 @@
       "name": "ocw-course-hugo-starter",
       "repo_url": "https://github.com/mitodl/ocw-course-hugo-starter.git",
       "channel_name": "ocw-course-hugo-starter",
-      "project_type": "web_application",
-      "web_application_type": "hugo",
-      "ci_hash_url": "https://ocw-www--ocw-next.netlify.app/static/hash.txt",
-      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/hash.txt",
+      "project_type": "library",
+      "packaging_tool": "npm",
       "announcements": false
     },
     {


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #294 

#### What's this PR do?
Reverts change for ocw-course-hugo-starter so it's treated as a library rather than a web application. There is some work to be done on the devops side to support deploying this project as a web application so until then we need to treat this as a library instead
