### PR TITLE
Switch ocw-to-hugo and ocw-course-hugo-starter to be treated as web applications

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -120,8 +120,11 @@
       "name": "ocw-to-hugo",
       "repo_url": "https://github.com/mitodl/ocw-to-hugo.git",
       "channel_name": "ocw-to-hugo",
-      "project_type": "library",
-      "packaging_tool": "npm",
+      "project_type": "web_application",
+      "web_application_type": "hugo",
+      "ci_hash_url": "https://ocw-www--ocw-next.netlify.app/static/ocw-to-hugo-hash.txt",
+      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-to-hugo-hash.txt",
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-to-hugo-hash.txt",
       "announcements": false
     },
     {
@@ -150,8 +153,11 @@
       "name": "ocw-course-hugo-starter",
       "repo_url": "https://github.com/mitodl/ocw-course-hugo-starter.git",
       "channel_name": "ocw-course-hugo-starter",
-      "project_type": "library",
-      "packaging_tool": "npm",
+      "project_type": "web_application",
+      "web_application_type": "hugo",
+      "ci_hash_url": "https://ocw-www--ocw-next.netlify.app/static/ocw-course-hugo-starter-hash.txt",
+      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-course-hugo-starter-hash.txt",
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-course-hugo-starter-hash.txt",
       "announcements": false
     },
     {


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #293 

#### What's this PR do?
Switches ocw-to-hugo and ocw-course-hugo-starter to be treated as web applications. Once the new hash files are created it should just work :crossed_fingers: 
