### PR TITLE
Include PR reference in commit message for ocw-course-hugo-starter

### DIFF
--- a/finish_release.py
+++ b/finish_release.py
@@ -10,7 +10,11 @@ from async_subprocess import (
 )
 from exception import VersionMismatchException
 from github import get_org_and_repo
-from lib import get_default_branch
+from lib import (
+    get_default_branch,
+    get_pr_ref,
+    get_release_pr,
+)
 from release import (
     init_working_dir,
     validate_dependencies,
@@ -116,7 +120,7 @@ def update_go_mod(*, path, version, repo_url):
     return False
 
 
-async def update_go_mod_and_commit(*, github_access_token, new_version, repo_info, go_mod_repo_url):
+async def update_go_mod_and_commit(*, github_access_token, new_version, repo_info, go_mod_repo_url, pull_request):
     """
     Create a new PR with an updated go.mod file
 
@@ -125,6 +129,7 @@ async def update_go_mod_and_commit(*, github_access_token, new_version, repo_inf
         new_version (str): The new version of the finished release
         repo_info (RepoInfo): The repository info for the finished release
         go_mod_repo_url (str): The repository info for the project with the go.mod file to update
+        pull_request (ReleasePR): The release PR
     """
     # go_mod is starter, finished repo is theme
     # theme was just merged, so we want to checkout and update starter's go.mod to point to the new version for theme
@@ -143,8 +148,9 @@ async def update_go_mod_and_commit(*, github_access_token, new_version, repo_inf
                 ["git", "add", "go.mod"],
                 cwd=go_mod_repo_path,
             )
+            pr_ref = get_pr_ref(pull_request.url)
             await check_call(
-                ["git", "commit", "-m", f"Update go.mod to reference {name}@{new_version}"],
+                ["git", "commit", "-m", f"Update go.mod to reference {name}@{new_version} from ({pr_ref})"],
                 cwd=go_mod_repo_path,
             )
             await check_call(["git", "push"], cwd=go_mod_repo_path)
@@ -164,6 +170,12 @@ async def finish_release(*, github_access_token, repo_info, version, timezone, g
 
     await validate_dependencies()
     async with init_working_dir(github_access_token, repo_info.repo_url) as working_dir:
+        org, repo = get_org_and_repo(repo_info.repo_url)
+        pr = await get_release_pr(
+            github_access_token=github_access_token,
+            org=org,
+            repo=repo,
+        )
         await check_release_tag(version, root=working_dir)
         await set_release_date(version, timezone, root=working_dir)
         await merge_release_candidate(root=working_dir)
@@ -176,4 +188,5 @@ async def finish_release(*, github_access_token, repo_info, version, timezone, g
                 new_version=version,
                 repo_info=repo_info,
                 go_mod_repo_url=go_mod_repo_url,
+                pull_request=pr,
             )

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -7,7 +7,10 @@ from pathlib import Path
 import pytest
 
 from exception import VersionMismatchException
-from lib import check_call
+from lib import (
+    check_call,
+    ReleasePR,
+)
 from release import create_release_notes
 from release_test import make_empty_commit
 from finish_release import (
@@ -94,6 +97,8 @@ async def test_finish_release(mocker, timezone, test_repo_directory, has_go_mod,
     merge_release_mock = mocker.async_patch('finish_release.merge_release')
     set_version_date_mock = mocker.async_patch('finish_release.set_release_date')
     update_go_mod_and_commit_mock = mocker.async_patch('finish_release.update_go_mod_and_commit')
+    release_pr = ReleasePR('version', 'https://github.com/org/repo/pull/123456', 'body')
+    mocker.async_patch('finish_release.get_release_pr', return_value=release_pr)
     go_mod_repo_url = "https://github.com/example-test/repo-with-go-mod.git"
 
     await finish_release(
@@ -116,6 +121,7 @@ async def test_finish_release(mocker, timezone, test_repo_directory, has_go_mod,
             new_version=version,
             repo_info=test_repo,
             go_mod_repo_url=go_mod_repo_url,
+            pull_request=release_pr,
         )
     else:
         assert update_go_mod_and_commit_mock.called is False
@@ -209,6 +215,7 @@ async def test_update_go_mod_and_commit(
         new_version=version,
         repo_info=library_test_repo,
         go_mod_repo_url=go_mod_repo_url,
+        pull_request=ReleasePR('version', 'https://github.com/org/repo/pull/123456', 'body')
     )
 
     update_go_mod_mock.assert_called_once_with(
@@ -220,7 +227,7 @@ async def test_update_go_mod_and_commit(
     init_working_dir_mock.assert_called_once_with(token, go_mod_repo_url)
     if changed:
         check_call_mock.assert_any_call(["git", "add", "go.mod"], cwd=Path(go_mod_repo_path))
-        message = f"Update go.mod to reference {library_test_repo.name}@{version}"
+        message = f"Update go.mod to reference {library_test_repo.name}@{version} from (org/repo#123456)"
         check_call_mock.assert_any_call(["git", "commit", "-m", message], cwd=Path(go_mod_repo_path))
         check_call_mock.assert_any_call(["git", "push"], cwd=Path(go_mod_repo_path))
     else:

--- a/lib.py
+++ b/lib.py
@@ -427,3 +427,20 @@ def remove_path_from_url(url):
     # The docs recommend _replace: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse
     updated = parsed._replace(path="", query="", fragment="")
     return urlunparse(updated)
+
+
+def get_pr_ref(url):
+    """
+    Convert a HTML link to a github pull request to a shorter piece of text that will still act as a link for github
+
+    Args:
+        url (str): A pull request URL, for example: https://github.com/mitodl/micromasters/pull/2993
+
+    Returns:
+        str: The shorter reference for a pull request. For example: mitodl/micromasters#2993
+    """
+    match = re.match(r".+://github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)", url)
+    if not match:
+        raise Exception(f"Unable to parse pull request URL: {url}")
+    org, repo, number = match.group("org"), match.group("repo"), match.group("number")
+    return f"{org}/{repo}#{number}"

--- a/lib_test.py
+++ b/lib_test.py
@@ -13,6 +13,7 @@ from constants import (
 from github import github_auth_headers
 from lib import (
     get_default_branch,
+    get_pr_ref,
     get_release_pr,
     get_unchecked_authors,
     load_repos_info,
@@ -361,3 +362,8 @@ async def test_get_default_branch(test_repo_directory):
     get_default_branch should get master or main, depending on the default branch in the repository
     """
     assert await get_default_branch(test_repo_directory) == "master"
+
+
+def test_get_pr_ref():
+    """get_pr_ref should convert a github pull request URL to a shorter reference"""
+    assert get_pr_ref("https://github.com/mitodl/micromasters/pull/2993") == "mitodl/micromasters#2993"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #304 

#### What's this PR do?
Includes PR reference in the commit message. The reference should cause github to tie the pull request for ocw-course-hugo-starter with the pull request for ocw-course-hugo-theme.

Essentially, instead of

    Update go.mod to reference ocw-course-hugo-theme@1.4.0 (dcba097e)

in the PR body for ocw-course-hugo-starter, you would see

    Update go.mod to reference ocw-course-hugo-theme@1.4.0 (dcba097e) (mitodl/ocw-course-hugo-theme#34)