### PR TITLE
Add npm install before npm publish

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -84,6 +84,7 @@ async def upload_to_npm(*, project_dir, npm_token):
     with open(Path(project_dir) / ".npmrc", "w") as f:
         f.write(f"//registry.npmjs.org/:_authToken={npm_token}")
 
+    await check_call(["npm", "install"], cwd=project_dir)
     await check_call(["npm", "publish"], cwd=project_dir)
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes an error where prepack commands weren't being run correctly. This runs npm install so that typecheck and other commands will be present when npm publish is run
