### PR TITLE
Refactor code which updates versions in other repositories

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -660,7 +660,6 @@ class Bot:
             repo_info=repo_info,
             version=version,
             timezone=self.timezone,
-            go_mod_repo_url=repo_info.go_mod_repo_info.repo_url if repo_info.go_mod_repo_info else None,
         )
 
         if repo_info.project_type == WEB_APPLICATION_TYPE:

--- a/bot_test.py
+++ b/bot_test.py
@@ -23,7 +23,7 @@ from constants import (
     PROD,
     RC,
     SETUPTOOLS,
-    VALID_PACKAGING_TOOL_TYPES,
+    NPM,
 )
 from exception import (
     ReleaseException,
@@ -550,7 +550,6 @@ async def test_finish_release(doof, mocker, project_type):
         repo_info=test_repo,
         version=version,
         timezone=doof.timezone,
-        go_mod_repo_url=None,
     )
     assert doof.said(f"Merged evil scheme {version} for {test_repo.name}!")
     if project_type == WEB_APPLICATION_TYPE:
@@ -632,16 +631,11 @@ async def test_webhook_different_callback_id(doof, mocker):
     assert finish_release_mock.called is False
 
 
-@pytest.mark.parametrize("has_go_mod_repo", [True, False])
-async def test_webhook_finish_release(doof, mocker, test_repo, library_test_repo, has_go_mod_repo):
+# pylint: disable=too-many-arguments
+async def test_webhook_finish_release(doof, mocker, test_repo, library_test_repo):
     """
     Finish the release
     """
-    if has_go_mod_repo:
-        test_repo = RepoInfo(
-            **{k: v for k, v in test_repo._asdict().items() if k != "go_mod_repo_info"},
-            go_mod_repo_info=library_test_repo,
-        )
     doof.repos_info = [test_repo, library_test_repo]
 
     pr_body = ReleasePR(
@@ -686,7 +680,6 @@ async def test_webhook_finish_release(doof, mocker, test_repo, library_test_repo
         repo_info=test_repo,
         version=pr_body.version,
         timezone=doof.timezone,
-        go_mod_repo_url=library_test_repo.repo_url if has_go_mod_repo else None,
     )
     assert doof.said("Merging...")
     assert not doof.said("Error")
@@ -855,7 +848,7 @@ async def test_reset(doof, test_repo):
 
 
 @pytest.mark.parametrize("command", [["publish"], ["upload", "to", "pypi"]])
-@pytest.mark.parametrize("packaging_tool", VALID_PACKAGING_TOOL_TYPES)
+@pytest.mark.parametrize("packaging_tool", [NPM, SETUPTOOLS])
 async def test_publish(doof, library_test_repo, mocker, command, packaging_tool):
     """the publish command should start the upload process"""
     publish_patched = mocker.async_patch('bot.publish')

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,7 @@ from constants import (
     SETUPTOOLS,
     WEB_APPLICATION_TYPE,
 )
-from repo_info import RepoInfo
+from repo_info import RepoInfo, UpdateOtherRepo
 from test_util import make_test_repo
 from test_util import async_wrapper
 
@@ -52,7 +52,7 @@ WEB_TEST_REPO_INFO = RepoInfo(
     web_application_type=DJANGO,
     packaging_tool=None,
     announcements=False,
-    go_mod_repo_info=None,
+    update_other_repos=[]
 )
 
 
@@ -70,19 +70,6 @@ def test_repo(test_repo_directory):
     yield WEB_TEST_REPO_INFO
 
 
-LIBRARY_TEST_REPO_INFO = RepoInfo(
-    name='lib_repo',
-    repo_url='http://github.com/mitodl/doof-lib.git',
-    prod_hash_url=None,
-    rc_hash_url=None,
-    ci_hash_url=None,
-    channel_id='doof-lib',
-    project_type=LIBRARY_TYPE,
-    packaging_tool=SETUPTOOLS,
-    web_application_type=None,
-    announcements=False,
-    go_mod_repo_info=None,
-)
 NPM_TEST_REPO_INFO = RepoInfo(
     name='node_doof',
     repo_url='http://github.com/mitodl/doof-node.git',
@@ -94,7 +81,22 @@ NPM_TEST_REPO_INFO = RepoInfo(
     packaging_tool=NPM,
     web_application_type=None,
     announcements=False,
-    go_mod_repo_info=None,
+    update_other_repos=[],
+)
+LIBRARY_TEST_REPO_INFO = RepoInfo(
+    name='lib_repo',
+    repo_url='http://github.com/mitodl/doof-lib.git',
+    prod_hash_url=None,
+    rc_hash_url=None,
+    ci_hash_url=None,
+    channel_id='doof-lib',
+    project_type=LIBRARY_TYPE,
+    packaging_tool=SETUPTOOLS,
+    web_application_type=None,
+    announcements=False,
+    update_other_repos=[
+        UpdateOtherRepo("node_doof", "npm", NPM_TEST_REPO_INFO)
+    ],
 )
 ANNOUNCEMENTS_CHANNEL = RepoInfo(
     name='doof_repo',
@@ -107,7 +109,7 @@ ANNOUNCEMENTS_CHANNEL = RepoInfo(
     web_application_type=None,
     packaging_tool=None,
     announcements=True,
-    go_mod_repo_info=None,
+    update_other_repos=[]
 )
 
 
@@ -126,6 +128,12 @@ def library_test_repo(library_test_repo_directory):
         f.write(SETUP_PY)
 
     yield LIBRARY_TEST_REPO_INFO
+
+
+@pytest.fixture
+def npm_library_test_repo(library_test_repo):
+    """Create a repository"""
+    yield NPM_TEST_REPO_INFO
 
 
 @pytest.fixture

--- a/constants.py
+++ b/constants.py
@@ -18,7 +18,8 @@ VALID_WEB_APPLICATION_TYPES = [DJANGO, HUGO]
 # packaging tool types
 NPM = "npm"
 SETUPTOOLS = "setuptools"
-VALID_PACKAGING_TOOL_TYPES = [NPM, SETUPTOOLS]
+GO = "go"
+VALID_PACKAGING_TOOL_TYPES = [NPM, SETUPTOOLS, GO]
 
 # deployment server types
 RC = "rc"
@@ -28,3 +29,4 @@ VALID_DEPLOYMENT_SERVER_TYPES = [CI, RC, PROD]
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 GIT_RELEASE_NOTES_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/git-release-notes")
+YARN_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/yarn")

--- a/lib_test.py
+++ b/lib_test.py
@@ -8,6 +8,7 @@ from constants import (
     DJANGO,
     LIBRARY_TYPE,
     NPM,
+    SETUPTOOLS,
     WEB_APPLICATION_TYPE,
 )
 from github import github_auth_headers
@@ -27,7 +28,7 @@ from lib import (
     remove_path_from_url,
     url_with_access_token,
 )
-from repo_info import RepoInfo
+from repo_info import RepoInfo, UpdateOtherRepo
 from test_util import async_wrapper, sync_call as call
 
 
@@ -267,7 +268,10 @@ async def test_load_repos_info(mocker):
                 "project_type": LIBRARY_TYPE,
                 "packaging_tool": NPM,
                 "announcements": False,
-                "go_mod": "bootcamp-ecommerce"
+                "update_other_repos": [{
+                    "name": "bootcamp-ecommerce",
+                    "packaging_tool": SETUPTOOLS
+                }],
             },
         ]
     })
@@ -283,7 +287,7 @@ async def test_load_repos_info(mocker):
         web_application_type=DJANGO,
         packaging_tool=None,
         announcements=False,
-        go_mod_repo_info=None,
+        update_other_repos=[]
     )
     expected_library = RepoInfo(
         name='bootcamp-ecommerce-library',
@@ -296,7 +300,13 @@ async def test_load_repos_info(mocker):
         web_application_type=None,
         packaging_tool=NPM,
         announcements=False,
-        go_mod_repo_info=expected_web_application,
+        update_other_repos=[
+            UpdateOtherRepo(
+                name="bootcamp-ecommerce",
+                packaging_tool=SETUPTOOLS,
+                repo_info=expected_web_application,
+            )
+        ]
     )
 
     assert load_repos_info({

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/mitodl/release-script.git"
   },
   "dependencies": {
-    "git-release-notes": "^2.1.0"
+    "git-release-notes": "^2.1.0",
+    "yarn": "^1.22.10"
   }
 }

--- a/publish_test.py
+++ b/publish_test.py
@@ -10,7 +10,6 @@ import pytest
 from constants import (
     NPM,
     SETUPTOOLS,
-    VALID_PACKAGING_TOOL_TYPES,
 )
 from lib import virtualenv
 from publish import upload_with_twine, upload_to_npm, upload_to_pypi, publish
@@ -81,7 +80,7 @@ async def test_upload_to_pypi(mocker, test_repo_directory, library_test_repo):
     assert twine_mocked.call_count == 1
 
 
-@pytest.mark.parametrize("packaging_tool", VALID_PACKAGING_TOOL_TYPES)
+@pytest.mark.parametrize("packaging_tool", [NPM, SETUPTOOLS])
 async def test_publish(mocker, test_repo_directory, library_test_repo, packaging_tool):
     """publish should call upload_to_pypi or upload_to_npm depending on the packaging_tool"""
     upload_to_pypi_mocked = mocker.async_patch('publish.upload_to_pypi')

--- a/release.py
+++ b/release.py
@@ -14,6 +14,7 @@ from async_subprocess import (
 from constants import (
     GIT_RELEASE_NOTES_PATH,
     SCRIPT_DIR,
+    YARN_PATH,
 )
 from exception import (
     DependencyException,
@@ -38,7 +39,7 @@ async def validate_dependencies():
         raise DependencyException('Please install git https://git-scm.com/downloads')
     if not await dependency_exists("node"):
         raise DependencyException('Please install node.js https://nodejs.org/')
-    if not await dependency_exists(GIT_RELEASE_NOTES_PATH):
+    if not await dependency_exists(GIT_RELEASE_NOTES_PATH) or not await dependency_exists(YARN_PATH):
         raise DependencyException("Please run 'npm install' first")
 
     version_output = await check_output(["node", "--version"], cwd="/")

--- a/repo_info.py
+++ b/repo_info.py
@@ -12,5 +12,11 @@ RepoInfo = namedtuple('RepoInfo', [
     'web_application_type',
     'packaging_tool',
     'announcements',
-    'go_mod_repo_info',
+    'update_other_repos'
+])
+
+UpdateOtherRepo = namedtuple("UpdateOtherRepo", [
+    "name",
+    "packaging_tool",
+    "repo_info"
 ])

--- a/repos_info.json
+++ b/repos_info.json
@@ -122,13 +122,7 @@
       "channel_name": "ocw-to-hugo",
       "project_type": "library",
       "packaging_tool": "npm",
-      "announcements": false,
-      "update_other_repos": [
-        {
-          "name": "ocw-course-hugo-theme",
-          "packaging_tool": "npm"
-        }
-      ]
+      "announcements": false
     },
     {
       "name": "ocw-www",

--- a/repos_info.json
+++ b/repos_info.json
@@ -120,11 +120,8 @@
       "name": "ocw-to-hugo",
       "repo_url": "https://github.com/mitodl/ocw-to-hugo.git",
       "channel_name": "ocw-to-hugo",
-      "project_type": "web_application",
-      "web_application_type": "hugo",
-      "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-to-hugo-hash.txt",
-      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-to-hugo-hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-to-hugo-hash.txt",
+      "project_type": "library",
+      "packaging_tool": "npm",
       "announcements": false
     },
     {

--- a/repos_info.json
+++ b/repos_info.json
@@ -122,7 +122,13 @@
       "channel_name": "ocw-to-hugo",
       "project_type": "library",
       "packaging_tool": "npm",
-      "announcements": false
+      "announcements": false,
+      "update_other_repos": [
+        {
+          "name": "ocw-course-hugo-theme",
+          "packaging_tool": "npm"
+        }
+      ]
     },
     {
       "name": "ocw-www",
@@ -164,7 +170,12 @@
       "project_type": "library",
       "packaging_tool": "npm",
       "announcements": false,
-      "go_mod": "ocw-course-hugo-starter"
+      "update_other_repos": [
+        {
+          "name": "ocw-course-hugo-starter",
+          "packaging_tool": "go"
+        }
+      ]
     },
     {
       "name": "course-search-utils",


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #313 

#### What's this PR do?
In general I tried to change things to be less specific to `go.mod`. In `repos_info.json` I changed it to `update_other_repos` with a dict including the `packaging_tool` to specify what kind of dependency to update, and there are similar changes in `finish_release.py` and elsewhere in the codebase. Note that `ocw-to-hugo` is also changed to a library project which updates `ocw-course-hugo-theme` in this PR.

