### PR TITLE
add ocw-hugo-themes and remove ocw-course-hugo-theme

### DIFF
--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -150,12 +150,13 @@ async def test_set_release_date_no_file(test_repo_directory, timezone, mocker):
 def test_update_go_mod(test_repo_directory, test_repo, has_require):
     """update_go_mod should update and replace a go.mod file"""
     go_mod_path = Path(test_repo_directory) / "go.mod"
-    contents = """module github.com/mitodl/ocw-course-hugo-starter
+    contents = """module github.com/mitodl/ocw-www
 
-go 1.13
+go 1.16
 
 """
-    require_line = "require github.com/mitodl/ocw-course-hugo-theme v0.0.0-20210111160843-361358c1de80 // indirect\n"
+    require_line = "require github.com/mitodl/ocw-hugo-themes/base-theme v0.0.0-20210429192641-b4d04aa624a0 // indirect"
+
     if has_require:
         contents += require_line
 
@@ -173,9 +174,9 @@ go 1.13
         new_contents = file.read()
 
     if has_require:
-        assert new_contents == """module github.com/mitodl/ocw-course-hugo-starter
+        assert new_contents == """module github.com/mitodl/ocw-www
 
-go 1.13
+go 1.16
 
 require github.com/mitodl/doof v4.5.6 // indirect
 """

--- a/repos_info.json
+++ b/repos_info.json
@@ -147,29 +147,15 @@
       "announcements": false
     },
     {
-      "name": "ocw-course-hugo-starter",
-      "repo_url": "https://github.com/mitodl/ocw-course-hugo-starter.git",
-      "channel_name": "ocw-course-hugo-starter",
+      "name": "ocw-hugo-themes",
+      "repo_url": "https://github.com/mitodl/ocw-hugo-themes.git",
+      "channel_name": "ocw-hugo-themes",
       "project_type": "web_application",
       "web_application_type": "hugo",
-      "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-course-hugo-starter-hash.txt",
-      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-course-hugo-starter-hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-course-hugo-starter-hash.txt",
+      "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-hugo-themes-hash.txt",
+      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-hugo-themes-hash.txt",
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-hugo-themes-hash.txt",
       "announcements": false
-    },
-    {
-      "name": "ocw-course-hugo-theme",
-      "repo_url": "https://github.com/mitodl/ocw-course-hugo-theme.git",
-      "channel_name": "ocw-course-hugo-theme",
-      "project_type": "library",
-      "packaging_tool": "npm",
-      "announcements": false,
-      "update_other_repos": [
-        {
-          "name": "ocw-course-hugo-starter",
-          "packaging_tool": "go"
-        }
-      ]
     },
     {
       "name": "course-search-utils",


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/release-script/issues/316

#### What's this PR do?
Going forward, all work on OCW Hugo themes will be done in `ocw-hugo-themes`.  This PR removes `ocw-course-hugo-theme` and `ocw-course-hugo-starter` and adds `ocw-hugo-themes` as a new repo to manage.

#### How should this be manually tested?
I'm not sure it can be tested locally, I think it will need to be released and then tested in Slack.
