### PR TITLE
Add command to start new releases for projects

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,7 +19,6 @@ from constants import (
     LIBRARY_TYPE,
     MINOR,
     NPM,
-    PATCH,
     PROD,
     RC,
     SETUPTOOLS,
@@ -1078,7 +1077,7 @@ class Bot:
                 command='start new releases',
                 parsers=[Parser(
                     func=parse_text_matching_options(VALID_RELEASE_ALL_TYPES),
-                    description=f"how to increment version for the next release (either 'minor' or 'patch')",
+                    description="how to increment version for the next release (either 'minor' or 'patch')",
                 )],
                 command_func=self.start_new_releases,
                 description="Start new releases for all projects which have new commits",

--- a/bot.py
+++ b/bot.py
@@ -17,11 +17,14 @@ from constants import (
     FINISH_RELEASE_ID,
     NEW_RELEASE_ID,
     LIBRARY_TYPE,
+    MINOR,
     NPM,
+    PATCH,
     PROD,
     RC,
     SETUPTOOLS,
     VALID_DEPLOYMENT_SERVER_TYPES,
+    VALID_RELEASE_ALL_TYPES,
     WEB_APPLICATION_TYPE,
 )
 from exception import (
@@ -64,8 +67,8 @@ from publish import publish
 from slack import get_channels_info, get_doofs_id
 from version import (
     get_commit_oneline_message,
+    get_project_version,
     get_version_tag,
-    update_version,
 )
 from wait_for_deploy import (
     fetch_release_hash,
@@ -290,10 +293,8 @@ class Bot:
             message_type=message_type,
         )
 
-    async def _library_release(self, command_args):
+    async def _library_release(self, *, repo_info, version):
         """Do a library release"""
-        repo_info = command_args.repo_info
-        version = command_args.args[0]
         channel_id = repo_info.channel_id
         org, repo = get_org_and_repo(repo_info.repo_url)
 
@@ -333,33 +334,41 @@ class Bot:
             ]
         )
 
-    async def _web_application_release(self, command_args, hotfix_version=None):
-        """Do a web application release"""
-        repo_info = command_args.repo_info
-        passed_arg = command_args.args[0]
+    async def _web_application_release(self, *, repo_info, version, hotfix_hash, manager):
+        """
+        Do a web application release
+
+        Args:
+            repo_info (RepoInfo): Repository info for a release
+            version (str): Version of a new release
+            hotfix_hash (str or None):
+                If present, treat this as a hotfix and use this for a commit hash.
+                If None, this is not a hotfix.
+            manager (str): Manager for the release
+        """
         channel_id = repo_info.channel_id
-        if hotfix_version:
+        if hotfix_hash:
             await release(
                 github_access_token=self.github_access_token,
                 repo_info=repo_info,
-                new_version=hotfix_version,
+                new_version=version,
                 branch='release',
-                commit_hash=passed_arg,
+                commit_hash=hotfix_hash,
             )
             await self.say(
                 channel_id=channel_id,
-                text=f"Behold, my new evil scheme - hotfix release {hotfix_version} "
-                     f"with commit {passed_arg}! Now deploying to RC..."
+                text=f"Behold, my new evil scheme - hotfix release {version} "
+                     f"with commit {hotfix_hash}! Now deploying to RC..."
             )
         else:
             await release(
                 github_access_token=self.github_access_token,
                 repo_info=repo_info,
-                new_version=passed_arg,
+                new_version=version,
             )
             await self.say(
                 channel_id=channel_id,
-                text=f"Behold, my new evil scheme - release {passed_arg} for {repo_info.name}! Now deploying to RC..."
+                text=f"Behold, my new evil scheme - release {version} for {repo_info.name}! Now deploying to RC..."
             )
 
         await self._wait_for_deploy_rc(
@@ -367,7 +376,7 @@ class Bot:
         )
         await self.wait_for_checkboxes(
             repo_info=repo_info,
-            manager=command_args.manager,
+            manager=manager,
         )
         self.loop.create_task(self.wait_for_checkboxes_reminder(repo_info=repo_info))
 
@@ -451,6 +460,24 @@ class Bot:
             is_announcement=True,
         )
 
+    async def _new_release(self, *, repo_info, version, manager):
+        """
+        Start a new release
+
+        Args:
+            repo_info (RepoInfo): Repository information for the release
+            version (str): The version of the new release
+            manager (str): Person starting a release
+        """
+        if repo_info.project_type == LIBRARY_TYPE:
+            await self._library_release(repo_info=repo_info, version=version)
+        elif repo_info.project_type == WEB_APPLICATION_TYPE:
+            await self._web_application_release(
+                repo_info=repo_info, version=version, hotfix_hash=None, manager=manager
+            )
+        else:
+            raise Exception("Configuration error: unknown project type {}".format(repo_info.project_type))
+
     async def release_command(self, command_args):
         """
         Start a new release and wait for deployment
@@ -459,6 +486,7 @@ class Bot:
             command_args (CommandArgs): The arguments for this command
         """
         repo_info = command_args.repo_info
+        version = command_args.args[0]
         repo_url = repo_info.repo_url
         org, repo = get_org_and_repo(repo_url)
         pr = await get_release_pr(
@@ -469,12 +497,7 @@ class Bot:
         if pr:
             raise ReleaseException("A release is already in progress: {}".format(pr.url))
 
-        if repo_info.project_type == LIBRARY_TYPE:
-            await self._library_release(command_args)
-        elif repo_info.project_type == WEB_APPLICATION_TYPE:
-            await self._web_application_release(command_args)
-        else:
-            raise Exception("Configuration error: unknown project type {}".format(repo_info.project_type))
+        await self._new_release(repo_info=repo_info, version=version, manager=command_args.manager)
 
     async def hotfix_command(self, command_args):
         """
@@ -484,6 +507,7 @@ class Bot:
             command_args (CommandArgs): The arguments for this command
         """
         repo_info = command_args.repo_info
+        hotfix_hash = command_args.args[0]
         repo_url = repo_info.repo_url
         org, repo = get_org_and_repo(repo_url)
 
@@ -496,11 +520,13 @@ class Bot:
             raise ReleaseException(f"There is a release already in progress: {release_pr.url}. Close that first!")
 
         async with init_working_dir(self.github_access_token, repo_info.repo_url) as working_dir:
-            last_version = await update_version(repo_info=repo_info, new_version="9.9.9", working_dir=working_dir)
+            last_version = await get_project_version(repo_info=repo_info, working_dir=working_dir)
 
         _, new_patch = next_versions(last_version)
 
-        await self._web_application_release(command_args, hotfix_version=new_patch)
+        await self._web_application_release(
+            repo_info=repo_info, version=new_patch, hotfix_hash=hotfix_hash, manager=command_args.manager
+        )
 
     async def wait_for_checkboxes_command(self, command_args):
         """
@@ -745,7 +771,7 @@ class Bot:
         repo_info = command_args.repo_info
         async with init_working_dir(self.github_access_token, repo_info.repo_url) as working_dir:
             default_branch = await get_default_branch(working_dir)
-            last_version = await update_version(repo_info=repo_info, new_version="9.9.9", working_dir=working_dir)
+            last_version = await get_project_version(repo_info=repo_info, working_dir=working_dir)
 
             release_notes = await create_release_notes(
                 last_version, with_checkboxes=False, base_branch=default_branch, root=working_dir
@@ -798,6 +824,38 @@ class Bot:
                     }
                 ]
             )
+
+    async def start_new_releases(self, command_args):
+        """
+        Start new releases for all projects with new commits
+
+        Args:
+            command_args (CommandArgs): The arguments for this command
+        """
+        new_release_type = command_args.args[0]
+
+        for repo_info in self.repos_info:
+            org, repo = get_org_and_repo(repo_info.repo_url)
+            release_pr = await get_release_pr(
+                github_access_token=self.github_access_token,
+                org=org,
+                repo=repo,
+            )
+            if release_pr:
+                # Release already in progress, skip
+                continue
+
+            async with init_working_dir(self.github_access_token, repo_info.repo_url) as working_dir:
+                last_version = await get_project_version(repo_info=repo_info, working_dir=working_dir)
+                default_branch = await get_default_branch(working_dir)
+                has_new_commits = await any_new_commits(last_version, base_branch=default_branch, root=working_dir)
+                if not has_new_commits:
+                    # Nothing to release
+                    continue
+
+            minor, patch = next_versions(last_version)
+            version = minor if new_release_type == MINOR else patch
+            await self._new_release(repo_info=repo_info, version=version, manager=command_args.manager)
 
     async def message_if_unchecked(self, repo_info):
         """
@@ -1015,6 +1073,16 @@ class Bot:
                 command_func=self.release_command,
                 description='Start a new release',
                 supported_project_types=[LIBRARY_TYPE, WEB_APPLICATION_TYPE],
+            ),
+            Command(
+                command='start new releases',
+                parsers=[Parser(
+                    func=parse_text_matching_options(VALID_RELEASE_ALL_TYPES),
+                    description=f"how to increment version for the next release (either 'minor' or 'patch')",
+                )],
+                command_func=self.start_new_releases,
+                description="Start new releases for all projects which have new commits",
+                supported_project_types=None
             ),
             Command(
                 command='release',

--- a/bot.py
+++ b/bot.py
@@ -854,7 +854,9 @@ class Bot:
 
             minor, patch = next_versions(last_version)
             version = minor if new_release_type == MINOR else patch
-            await self._new_release(repo_info=repo_info, version=version, manager=command_args.manager)
+            self.loop.create_task(
+                self._new_release(repo_info=repo_info, version=version, manager=command_args.manager)
+            )
 
     async def message_if_unchecked(self, repo_info):
         """

--- a/bot_test.py
+++ b/bot_test.py
@@ -1315,7 +1315,8 @@ async def test_start_new_releases(
     new_release_mock = mocker.async_patch("bot.Bot._new_release")
 
     await doof.start_new_releases(command_args)
-
+    # iterate once through event loop
+    await asyncio.sleep(0)
     get_release_pr_mock.assert_any_call(github_access_token=GITHUB_ACCESS, org=org, repo=repo)
 
     if not has_release_pr:

--- a/bot_test.py
+++ b/bot_test.py
@@ -719,9 +719,6 @@ async def test_webhook_start_release(doof, test_repo, mocker):
     """
     Start a new release
     """
-    org, repo = get_org_and_repo(test_repo.repo_url)
-    get_release_pr_mock = mocker.async_patch('bot.get_release_pr', return_value=None)
-
     release_mock = mocker.async_patch('bot.Bot.release_command')
 
     version = "3.4.5"

--- a/constants.py
+++ b/constants.py
@@ -27,6 +27,10 @@ CI = "ci"
 PROD = "prod"
 VALID_DEPLOYMENT_SERVER_TYPES = [CI, RC, PROD]
 
+MINOR = "minor"
+PATCH = "patch"
+VALID_RELEASE_ALL_TYPES = [MINOR, PATCH]
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 GIT_RELEASE_NOTES_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/git-release-notes")
 YARN_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/yarn")

--- a/lib.py
+++ b/lib.py
@@ -322,7 +322,7 @@ def load_repos_info(channel_lookup):
     infos = [
         RepoInfo(
             name=repo_info['name'],
-            repo_url=repo_info.get('repo_url'),
+            repo_url=repo_info['repo_url'],
             ci_hash_url=(
                 repo_info["ci_hash_url"] if repo_info.get("project_type") == WEB_APPLICATION_TYPE else None
             ),
@@ -338,7 +338,7 @@ def load_repos_info(channel_lookup):
             packaging_tool=repo_info.get('packaging_tool'),
             announcements=repo_info.get('announcements'),
             update_other_repos=[]  # this is filled in below
-        ) for repo_info in repos_info['repos']
+        ) for repo_info in repos_info['repos'] if repo_info.get("repo_url")
     ]
 
     repo_dict_lookup = {info["name"]: info for info in repos_info["repos"]}

--- a/release.py
+++ b/release.py
@@ -178,7 +178,9 @@ async def release(*, github_access_token, repo_info, new_version, branch=None, c
                 await check_call(["git", "cherry-pick", commit_hash], cwd=working_dir)
             except CalledProcessError as ex:
                 raise ReleaseException(f"Cherry pick failed for the given hash {commit_hash}") from ex
-        old_version = await update_version(repo_info=repo_info, new_version=new_version, working_dir=working_dir)
+        old_version = await update_version(
+            repo_info=repo_info, new_version=new_version, working_dir=working_dir, readonly=False
+        )
         if parse_version(old_version) >= parse_version(new_version):
             raise ReleaseException("old version is {old} but the new version {new} is not newer".format(
                 old=old_version,

--- a/release_test.py
+++ b/release_test.py
@@ -372,7 +372,7 @@ async def test_release(mocker, hotfix_hash, test_repo_directory, test_repo):
         old_version, new_version, base_branch=base_branch, root=test_repo_directory
     )
     update_version_mock.assert_called_once_with(
-        repo_info=test_repo, new_version=new_version, working_dir=test_repo_directory,
+        repo_info=test_repo, new_version=new_version, working_dir=test_repo_directory, readonly=False
     )
     check_call_mock.assert_any_call(["git", "checkout", "-qb", "release-candidate"], cwd=test_repo_directory)
     if hotfix_hash:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #264 

#### What's this PR do?
Starts releases on all projects which need new releases. A user would run `@doof start new releases minor` and new releases would be started in their respective channels, as long as they have commits which need releasing, and as long as there is not already a release in progress.