### PR TITLE
Use github labels to track release state

### DIFF
--- a/client_wrapper.py
+++ b/client_wrapper.py
@@ -12,3 +12,7 @@ class ClientWrapper:
     async def post(self, *args, **kwargs):
         """POST request"""
         return requests.post(*args, **kwargs)
+
+    async def delete(self, *args, **kwargs):
+        """DELETE request"""
+        return requests.delete(*args, **kwargs)

--- a/constants.py
+++ b/constants.py
@@ -34,3 +34,17 @@ VALID_RELEASE_ALL_TYPES = [MINOR, PATCH]
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 GIT_RELEASE_NOTES_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/git-release-notes")
 YARN_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/yarn")
+
+ALL_CHECKBOXES_CHECKED = "all checkboxes checked"
+DEPLOYING_TO_RC = "deploying to rc"
+WAITING_FOR_CHECKBOXES = "waiting for checkboxes"
+DEPLOYING_TO_PROD = "deploying to prod"
+DEPLOYED_TO_PROD = "deployed to prod"
+RELEASE_LABELS = [
+    ALL_CHECKBOXES_CHECKED,
+    DEPLOYING_TO_RC,
+    WAITING_FOR_CHECKBOXES,
+    DEPLOYING_TO_PROD,
+    DEPLOYED_TO_PROD,
+]
+FREEZE_RELEASE = "freeze release"

--- a/github_test.py
+++ b/github_test.py
@@ -1,12 +1,16 @@
 """Tests for github functions"""
 import json
 import os
+from urllib.parse import quote
 
 import pytest
 
 from constants import SCRIPT_DIR
 from github import (
+    add_label,
     create_pr,
+    delete_label,
+    get_labels,
     get_org_and_repo,
     github_auth_headers,
     needs_review,
@@ -120,3 +124,100 @@ async def test_get_org_and_repo():
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+NEEDS_REVIEW_LABEL_JSON = {
+    'id': 324682350,
+    'node_id': 'MDU6TGFiZWwzMjQ2ODIzNTA=',
+    'url': 'https://api.github.com/repos/mitodl/release-script/labels/Needs%20review',
+    'name': 'Needs review',
+    'color': 'fef2c0',
+    'default': False,
+    'description': None
+}
+TESTING_LABEL_JSON = {
+    'id': 2994207717,
+    'node_id': 'MDU6TGFiZWwyOTk0MjA3NzE3',
+    'url': 'https://api.github.com/repos/mitodl/release-script/labels/testing',
+    'name': 'testing',
+    'color': 'ededed',
+    'default': False,
+    'description': None
+}
+async def test_get_labels(mocker):
+    """get_labels should retrieve labels from github"""
+    response = mocker.Mock(json=mocker.Mock(return_value=[NEEDS_REVIEW_LABEL_JSON, TESTING_LABEL_JSON]))
+    patched = mocker.async_patch('client_wrapper.ClientWrapper.get', return_value=response)
+    token = "token"
+    org = "mitodl"
+    repo = "release-script"
+    repo_url = f"git@github.com:{org}/{repo}.git"
+    pr_number = 1234
+
+    assert await get_labels(
+        github_access_token=token,
+        repo_url=repo_url,
+        pr_number=pr_number
+    ) == [NEEDS_REVIEW_LABEL_JSON['name'], TESTING_LABEL_JSON['name']]
+    patched.assert_called_once_with(
+        mocker.ANY,
+        f"https://api.github.com/repos/{org}/{repo}/issues/{pr_number}/labels",
+        headers=github_auth_headers(token),
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+async def test_add_label(mocker):
+    """add_label should add a new label on a pr"""
+    response = mocker.Mock()
+    patched = mocker.async_patch('client_wrapper.ClientWrapper.post', return_value=response)
+    token = "token"
+    org = "mitodl"
+    repo = "release-script"
+    repo_url = f"git@github.com:{org}/{repo}.git"
+    pr_number = 1234
+    label = "new label"
+
+    await add_label(
+        github_access_token=token,
+        repo_url=repo_url,
+        pr_number=pr_number,
+        label=label,
+    )
+    patched.assert_called_once_with(
+        mocker.ANY,
+        f"https://api.github.com/repos/{org}/{repo}/issues/{pr_number}/labels",
+        json={"labels": [label]},
+        headers=github_auth_headers(token),
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.parametrize("status, expected_raise_for_status", [
+    [200, True],
+    [400, True],
+    [404, False]
+])
+async def test_delete_label(mocker, status, expected_raise_for_status):
+    """delete_label should remove a label from a pr"""
+    response = mocker.Mock(status_code=status)
+    patched = mocker.async_patch('client_wrapper.ClientWrapper.delete', return_value=response)
+    token = "token"
+    org = "mitodl"
+    repo = "release-script"
+    repo_url = f"git@github.com:{org}/{repo}.git"
+    pr_number = 1234
+    label = "existing label"
+
+    await delete_label(
+        github_access_token=token,
+        repo_url=repo_url,
+        pr_number=pr_number,
+        label=label,
+    )
+    patched.assert_called_once_with(
+        mocker.ANY,
+        f"https://api.github.com/repos/{org}/{repo}/issues/{pr_number}/labels/{quote(label)}",
+        headers=github_auth_headers(token),
+    )
+    assert response.raise_for_status.called is expected_raise_for_status

--- a/lib.py
+++ b/lib.py
@@ -27,7 +27,7 @@ from github import (
 from repo_info import RepoInfo
 
 
-ReleasePR = namedtuple("ReleasePR", ['version', 'url', 'body'])
+ReleasePR = namedtuple("ReleasePR", ['version', 'url', 'body', 'number'])
 
 
 VERSION_RE = r'\d+\.\d+\.\d+'
@@ -103,6 +103,7 @@ async def get_release_pr(*, github_access_token, org, repo):
 
     return ReleasePR(
         version=version,
+        number=pr["number"],
         body=pr['body'],
         url=pr['html_url'],
     )

--- a/lib_test.py
+++ b/lib_test.py
@@ -49,6 +49,7 @@ OTHER_PR = {
     "head": {
         "ref": "other-branch"
     },
+    "number": 345
 }
 RELEASE_PR = {
     "url": "https://api.github.com/repos/mitodl/micromasters/pulls/2993",
@@ -58,6 +59,7 @@ RELEASE_PR = {
     "head": {
         "ref": "release-candidate"
     },
+    "number": 234,
 }
 FAKE_PULLS = [OTHER_PR, RELEASE_PR]
 
@@ -104,6 +106,7 @@ async def test_get_release_pr(mocker):
     assert pr.body == RELEASE_PR['body']
     assert pr.url == RELEASE_PR['html_url']
     assert pr.version == '0.53.3'
+    assert pr.number == 234
 
 
 async def test_get_release_pr_no_pulls(mocker):
@@ -163,7 +166,8 @@ async def test_get_unchecked_authors(mocker):
     get_release_pr_mock = mocker.async_patch('lib.get_release_pr', return_value=ReleasePR(
         body=FAKE_RELEASE_PR_BODY,
         version='1.2.3',
-        url='http://url'
+        url='http://url',
+        number=234,
     ))
     unchecked = await get_unchecked_authors(
         github_access_token=access_token,

--- a/release.py
+++ b/release.py
@@ -190,7 +190,7 @@ async def release(*, github_access_token, repo_info, new_version, branch=None, c
         await verify_new_commits(old_version, base_branch=base_branch, root=working_dir)
         await update_release_notes(old_version, new_version, base_branch=base_branch, root=working_dir)
         await build_release(root=working_dir)
-        await generate_release_pr(
+        return await generate_release_pr(
             github_access_token=github_access_token,
             repo_url=repo_info.repo_url,
             old_version=old_version,

--- a/wait_for_deploy.py
+++ b/wait_for_deploy.py
@@ -20,16 +20,6 @@ async def fetch_release_hash(hash_url):
     return release_hash
 
 
-async def is_release_deployed(*, github_access_token, repo_url, hash_url, branch):
-    """
-    Is server finished with the deploy?
-    """
-    async with init_working_dir(github_access_token, repo_url) as working_dir:
-        output = await check_output(["git", "rev-parse", "origin/{}".format(branch)], cwd=working_dir)
-        latest_hash = output.decode().strip()
-    return await fetch_release_hash(hash_url) == latest_hash
-
-
 async def wait_for_deploy(*, github_access_token, repo_url, hash_url, watch_branch):
     """
     Wait until server is finished with the deploy


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #311

#### What's this PR do?
Essentially this will create a release lifecycle where the state is managed with github labels:
 - When a new release is created, Doof will start a deployment and set the `deploying to rc` label. (When Doof sets a label he will remove other release labels,  ignoring other non-release labels already set, and will replace other release-specific labels)
 - Once the release is deployed, Doof will set the label to `wait for checkboxes`
 - Doof will wait for checkboxes then set the label `all checkboxes checked` once all checkboxes are checked off
 - When the manager finishes the release, doof will set a label `deploying to prod`
 - When production is deployed, doof will set the label `deployed to prod`

Heroku can restart doof at any time, so the intent is to provide information so doof can pick up where he left off. Doof does this already but it's a bit haphazard and buggy. In `Doof.startup` doof will loop through all repositories and attempt to pick up where he left off by acting on the release label.

Additionally, there will be a `freeze release` label which will tell doof to ignore that repository for the time being so that `start new releases` would not start a release there. That tag will be set by the release manager manually by adding the label to the release themselves.

Library projects would not use the release labels, but they would still respect a `freeze release` label.