### PR TITLE
Check closed PRs in addition to open PRs when doof starts up

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1376,6 +1376,7 @@ class Bot:
                 github_access_token=self.github_access_token,
                 org=org,
                 repo=repo,
+                all_prs=True,
             )
             if not release_pr:
                 continue

--- a/lib.py
+++ b/lib.py
@@ -74,7 +74,7 @@ def parse_checkmarks(body):
     return commits
 
 
-async def get_release_pr(*, github_access_token, org, repo):
+async def get_release_pr(*, github_access_token, org, repo, all_prs=False):
     """
     Look up the pull request information for a release, or return None if it doesn't exist
 
@@ -82,6 +82,9 @@ async def get_release_pr(*, github_access_token, org, repo):
         github_access_token (str): The github access token
         org (str): The github organization (eg mitodl)
         repo (str): The github repository (eg micromasters)
+        all_prs (bool):
+            If True, look through open and closed PRs. The most recent release PR will be returned.
+            If False, look only through open PRs.
 
     Returns:
         ReleasePR: The information about the release pull request, or None if there is no release PR in progress
@@ -91,6 +94,7 @@ async def get_release_pr(*, github_access_token, org, repo):
         org=org,
         repo=repo,
         branch='release-candidate',
+        all_prs=all_prs,
     )
     if pr is None:
         return None

--- a/test_constants.py
+++ b/test_constants.py
@@ -1,0 +1,33 @@
+"""Constants used in unit test"""
+
+
+FAKE_RELEASE_PR_BODY = """
+
+## Alice Pote
+  - [x] Implemented AutomaticEmail API ([5de04973](../commit/5de049732f769ec8a2a24068514603f353e13ed4))
+  - [ ] Unmarked some files as executable ([c665a2c7](../commit/c665a2c79eaf5e2d54b18f5a880709f5065ed517))
+
+## Nathan Levesque
+  - [x] Fixed seed data for naive timestamps (#2712) ([50d19c4a](../commit/50d19c4adf22c5ddc8b8299f4b4579c2b1e35b7f))
+  - [garbage] xyz
+    """
+OTHER_PR = {
+    "url": "https://api.github.com/repos/mitodl/micromasters/pulls/2985",
+    "html_url": "https://github.com/mitodl/micromasters/pull/2985",
+    "body": "not a release",
+    "title": "not a release",
+    "head": {
+        "ref": "other-branch"
+    },
+    "number": 345
+}
+RELEASE_PR = {
+    "url": "https://api.github.com/repos/mitodl/micromasters/pulls/2993",
+    "html_url": "https://github.com/mitodl/micromasters/pull/2993",
+    "body": FAKE_RELEASE_PR_BODY,
+    "title": "Release 0.53.3",
+    "head": {
+        "ref": "release-candidate"
+    },
+    "number": 234,
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #329 

#### What's this PR do?
Fixes an edge case. Doof currently ignores closed release PRs entirely which is usually the right decision. However with #323 we started having doof read github labels from projects to learn release state. There is an edge case where doof may merge a release, wait for deployment to production, and be restarted by heroku in that time. In that case the release would be deployed but doof would not say anything because doof wasn't checking the status of merged release PRs.

This PR should change that so that doof will see that the PR is deploying to production. Then doof will wait for the deployment and announce the successful deployment.