### PR TITLE
Retry on 502 and 503 responses

### DIFF
--- a/client_wrapper.py
+++ b/client_wrapper.py
@@ -9,7 +9,7 @@ class ClientWrapper:
 
     def __init__(self):
         self.session = requests.Session()
-        adapter = HTTPAdapter(max_retries=Retry())
+        adapter = HTTPAdapter(max_retries=Retry(status_forcelist=[502, 503]))
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #335 

#### What's this PR do?
Currently doof will restart requests on connection failures but requests weren't retried on HTTP errors like the 502 error in #335 and [the 503 error in this comment](https://github.com/mitodl/release-script/issues/332#issuecomment-853021454). This should cause these requests to be retried if the response has either of these two status codes