### PR TITLE
add the none packaging type

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -16,10 +16,11 @@ HUGO = "hugo"
 VALID_WEB_APPLICATION_TYPES = [DJANGO, HUGO]
 
 # packaging tool types
+NONE = "none"
 NPM = "npm"
 SETUPTOOLS = "setuptools"
 GO = "go"
-VALID_PACKAGING_TOOL_TYPES = [NPM, SETUPTOOLS, GO]
+VALID_PACKAGING_TOOL_TYPES = [NONE, NPM, SETUPTOOLS, GO]
 
 # deployment server types
 RC = "rc"

--- a/release_test.py
+++ b/release_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-with
 """Tests for release script"""
 import os
 from subprocess import CalledProcessError

--- a/version.py
+++ b/version.py
@@ -215,7 +215,7 @@ async def update_version_file(*, new_version, working_dir, readonly):
         old_version = f.readline()
     if not readonly:
         await check_output(
-            ["sed", "-n", "/^#{new_version}/p;q", "VERSION"], cwd=working_dir
+            ["sed", "-n", "/^#{}/p;q".format(new_version), "VERSION"], cwd=working_dir
         )
     return old_version
 

--- a/version.py
+++ b/version.py
@@ -213,11 +213,12 @@ async def update_version_file(*, new_version, working_dir, readonly):
     """
     old_version = None
     version_file = Path(working_dir) / "VERSION"
-    with open(version_file, "r") as f:
-        old_version = f.readline()
-    if not readonly:
-        with open(version_file, "w") as f:
-            f.write(new_version)
+    if version_file.is_file():
+        with open(version_file, "r") as f:
+            old_version = f.readline()
+        if not readonly:
+            with open(version_file, "w") as f:
+                f.write(new_version)
     return old_version
 
 

--- a/version.py
+++ b/version.py
@@ -198,6 +198,19 @@ async def update_npm_version(*, new_version, working_dir, readonly):
 
 
 async def update_version_file(*, new_version, working_dir, readonly):
+    """
+    Update a VERSION file.
+
+    Args:
+        new_version (str): The new version
+        working_dir (str): The directory of the library
+        readonly (bool): If true, return the old version if found but don't actually write changes to any files
+
+    Returns:
+        str:
+            The old version which has been successfully replaced with the new version.
+            On error, an exception will raise.
+    """
     with open(Path(working_dir) / "VERSION", "r") as f:
         old_version = f.readline()
     if not readonly:

--- a/version.py
+++ b/version.py
@@ -211,12 +211,13 @@ async def update_version_file(*, new_version, working_dir, readonly):
             The old version which has been successfully replaced with the new version.
             On error, an exception will raise.
     """
-    with open(Path(working_dir) / "VERSION", "r") as f:
+    old_version = None
+    version_file = Path(working_dir) / "VERSION"
+    with open(version_file, "r") as f:
         old_version = f.readline()
     if not readonly:
-        await check_output(
-            ["sed", "-n", "/^#{}/p;q".format(new_version), "VERSION"], cwd=working_dir
-        )
+        with open(version_file, "w") as f:
+            f.write(new_version)
     return old_version
 
 

--- a/version.py
+++ b/version.py
@@ -11,6 +11,7 @@ from constants import (
     DJANGO,
     HUGO,
     LIBRARY_TYPE,
+    NONE,
     NPM,
     SETUPTOOLS,
     WEB_APPLICATION_TYPE,
@@ -196,6 +197,16 @@ async def update_npm_version(*, new_version, working_dir, readonly):
     return old_version
 
 
+async def update_version_file(*, new_version, working_dir, readonly):
+    with open(Path(working_dir) / "VERSION", "r") as f:
+        old_version = f.readline()
+    if not readonly:
+        await check_output(
+            ["sed", "-n", "/^#{new_version}/p;q", "VERSION"], cwd=working_dir
+        )
+    return old_version
+
+
 async def get_project_version(*, repo_info, working_dir):
     """
     Look up the version of a project from the project instance in the working directory
@@ -240,5 +251,9 @@ async def update_version(*, repo_info, new_version, working_dir, readonly):
             )
         elif repo_info.packaging_tool == NPM:
             return await update_npm_version(
+                new_version=new_version, working_dir=working_dir, readonly=readonly
+            )
+        elif repo_info.packaging_tool == NONE:
+            return await update_version_file(
                 new_version=new_version, working_dir=working_dir, readonly=readonly
             )

--- a/version_test.py
+++ b/version_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=consider-using-with
 """Test version functions"""
 import json
 import os
@@ -292,7 +293,7 @@ async def test_update_npm_version(readonly):
 
 @pytest.mark.parametrize("readonly", [True, False])
 async def test_update_version_file(readonly):
-    """update version for an npm package"""
+    """update version for a version file"""
     old_version = "0.76.54"
     new_version = "0.99.99"
 

--- a/version_test.py
+++ b/version_test.py
@@ -23,6 +23,7 @@ from version import (
     update_version,
     update_python_version_in_file,
     update_npm_version,
+    update_version_file,
 )
 
 
@@ -287,6 +288,25 @@ async def test_update_npm_version(readonly):
         assert received == old_version
         with open(package_json_path) as f:
             assert json.load(f) == {"version": old_version if readonly else new_version}
+
+
+@pytest.mark.parametrize("readonly", [True, False])
+async def test_update_version_file(readonly):
+    """update version for an npm package"""
+    old_version = "0.76.54"
+    new_version = "0.99.99"
+
+    with TemporaryDirectory() as working_dir:
+        version_file_path = Path(working_dir) / "VERSION"
+        with open(version_file_path, "w") as f:
+            f.write(old_version)
+
+        received = await update_version_file(
+            new_version=new_version, working_dir=working_dir, readonly=readonly
+        )
+        assert received == old_version
+        with open(version_file_path) as f:
+            assert f.readline() == old_version if readonly else new_version
 
 
 # pylint: disable=too-many-arguments


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/release-script/issues/340

#### What's this PR do?
This PR adds the "none" packaging type to library type projects, allowing the handling of releases for a repo that does not publish its code externally.

#### How should this be manually tested?
I'm not exactly sure how this would be tested, aside from merging the PR and creating a watched repo with the "none" packaging type

#### Any background context you want to provide?
This is mostly being implemented to support managing https://github.com/mitodl/ocw-hugo-projects, which fires off webhooks to `ocw-studio` to update `WebsiteStarter` configurations on push events.  In this case, doof doesn't need to handle publishing any library because the webhooks perform the necessary actions.  All it needs to do is merge the code and handle the version.
