### PR TITLE
update URLs for mitxonline

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -167,9 +167,9 @@
     {
       "name": "mitxonline",
       "repo_url": "https://github.com/mitodl/mitxonline.git",
-      "ci_hash_url": "https://mitxonline-ci.odl.mit.edu/static/hash.txt",
-      "rc_hash_url": "https://mitxonline-rc.odl.mit.edu/static/hash.txt",
-      "prod_hash_url": "https://mitxonline.odl.mit.edu/static/hash.txt",
+      "ci_hash_url": "https://mitxonline-ci.mitxonline.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://mitxonline-rc.mitxonline.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://mitxonline.mit.edu/static/hash.txt",
       "channel_name": "mitxonline-eng",
       "project_type": "web_application",
       "web_application_type": "django"


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR updates the URLs for mitxonline to replace `odl` with `mitxonline`

#### How should this be manually tested?
N/A

