### PR TITLE
Add command to show status across all repos

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,8 +18,6 @@ from constants import (
     DEPLOYING_TO_PROD,
     DEPLOYING_TO_RC,
     WAITING_FOR_CHECKBOXES,
-    RELEASE_LABELS,
-    FREEZE_RELEASE,
     FINISH_RELEASE_ID,
     NEW_RELEASE_ID,
     LIBRARY_TYPE,
@@ -38,7 +36,6 @@ from exception import (
 )
 from finish_release import finish_release
 from github import (
-    get_labels,
     get_org_and_repo,
     needs_review,
     set_release_label,
@@ -65,6 +62,11 @@ from lib import (
 )
 from publish import publish
 from slack import get_channels_info, get_doofs_id
+from status import (
+    format_status_for_repo,
+    status_for_repo_last_pr,
+    status_for_repo_new_commits,
+)
 from version import (
     get_commit_oneline_message,
     get_project_version,
@@ -307,40 +309,6 @@ class Bot:
             message_type=message_type,
         )
 
-    async def _get_release_label(self, *, repo_url, pr_number):
-        """
-        Helper function to get release labels on a repo. If there is a merge freeze label, a None is returned as if
-        there were no labels at all (which means ignore the repository).
-
-        Args:
-            repo_url (str): URL for a repository
-            pr_number (int): Pull request number
-        """
-        labels = await get_labels(
-            github_access_token=self.github_access_token,
-            repo_url=repo_url,
-            pr_number=pr_number,
-        )
-        if FREEZE_RELEASE in labels:
-            return None
-
-        labels = [label for label in labels if label in RELEASE_LABELS]
-        if len(labels) > 1:
-            raise Exception(f"Multiple release labels found for {repo_url}: {labels}")
-        if len(labels) == 0:
-            # A library release, or maybe a release made before these changes were made
-            return None
-        return labels[0]
-
-    async def _set_release_label(self, *, repo_url, pr_number, label):
-        """Helper function to set a release PR label (and make mocking easier)"""
-        await set_release_label(
-            github_access_token=self.github_access_token,
-            repo_url=repo_url,
-            pr_number=pr_number,
-            label=label,
-        )
-
     async def run_release_lifecycle(self, *, repo_info, manager, release_pr):
         """
         Look up the release step from the label, then continue release from that step
@@ -350,8 +318,8 @@ class Bot:
             manager (str): Release manager
             release_pr (ReleasePR): Release pull request
         """
-        label = await self._get_release_label(
-            repo_url=repo_info.repo_url, pr_number=release_pr.number
+        status = await status_for_repo_last_pr(
+            repo_info=repo_info, github_access_token=self.github_access_token
         )
 
         # In general these functions should put things in this order:
@@ -362,22 +330,22 @@ class Bot:
         #  - call this function again to decide on the next step
         # The intention is that if a function terminates unexpectedly it
         # can start over with as little repeated speech/actions as possible.
-        if label == DEPLOYING_TO_RC:
+        if status == DEPLOYING_TO_RC:
             await self._wait_for_deploy_rc(
                 repo_info=repo_info, manager=manager, release_pr=release_pr
             )
-        elif label == WAITING_FOR_CHECKBOXES:
+        elif status == WAITING_FOR_CHECKBOXES:
             await self.wait_for_checkboxes(
                 repo_info=repo_info, manager=manager, release_pr=release_pr
             )
-        elif label == ALL_CHECKBOXES_CHECKED:
+        elif status == ALL_CHECKBOXES_CHECKED:
             # Done, waiting for the release to finish
             return
-        elif label == DEPLOYING_TO_PROD:
+        elif status == DEPLOYING_TO_PROD:
             await self._wait_for_deploy_prod(
                 repo_info=repo_info, manager=manager, release_pr=release_pr
             )
-        elif label == DEPLOYED_TO_PROD:
+        elif status == DEPLOYED_TO_PROD:
             # all done
             return
 
@@ -465,7 +433,8 @@ class Bot:
         release_pr = await get_release_pr(
             github_access_token=self.github_access_token, org=org, repo=repo
         )
-        await self._set_release_label(
+        await set_release_label(
+            github_access_token=self.github_access_token,
             repo_url=repo_info.repo_url,
             pr_number=release_pr.number,
             label=DEPLOYING_TO_RC,
@@ -488,7 +457,8 @@ class Bot:
         )
         rc_server = remove_path_from_url(repo_info.rc_hash_url)
 
-        await self._set_release_label(
+        await set_release_label(
+            github_access_token=self.github_access_token,
             repo_url=repo_url,
             pr_number=release_pr.number,
             label=WAITING_FOR_CHECKBOXES,
@@ -524,7 +494,8 @@ class Bot:
             hash_url=repo_info.prod_hash_url,
             watch_branch="release",
         )
-        await self._set_release_label(
+        await set_release_label(
+            github_access_token=self.github_access_token,
             repo_url=repo_url,
             pr_number=release_pr.number,
             label=DEPLOYED_TO_PROD,
@@ -643,7 +614,8 @@ class Bot:
             org=org,
             repo=repo,
         )
-        await self._set_release_label(
+        await set_release_label(
+            github_access_token=self.github_access_token,
             repo_url=command_args.repo_info.repo_url,
             pr_number=release_pr.number,
             label=WAITING_FOR_CHECKBOXES,
@@ -724,7 +696,8 @@ class Bot:
                 )
             prev_unchecked_authors = new_unchecked_authors
 
-        await self._set_release_label(
+        await set_release_label(
+            github_access_token=self.github_access_token,
             repo_url=repo_url,
             pr_number=release_pr.number,
             label=ALL_CHECKBOXES_CHECKED,
@@ -834,7 +807,8 @@ class Bot:
                     project=repo_info.name,
                 ),
             )
-            await self._set_release_label(
+            await set_release_label(
+                github_access_token=self.github_access_token,
                 repo_url=repo_url,
                 pr_number=pr.number,
                 label=DEPLOYING_TO_PROD,
@@ -1050,6 +1024,44 @@ class Bot:
                 channel_id=command_args.channel_id, text="No new releases needed"
             )
 
+    async def status(self, command_args):
+        """Show the status of all repos"""
+        await self.say(
+            channel_id=command_args.channel_id, text="Calculating release statuses..."
+        )
+
+        sorted_repos_info = sorted(
+            self.repos_info, key=lambda _repo_info: _repo_info.name
+        )
+
+        no_news = []
+        text = ""
+        for repo_info in sorted_repos_info:
+            status = await status_for_repo_last_pr(
+                github_access_token=self.github_access_token,
+                repo_info=repo_info,
+            )
+            has_new_commits = await status_for_repo_new_commits(
+                github_access_token=self.github_access_token,
+                repo_info=repo_info,
+            )
+            status_string = format_status_for_repo(
+                current_status=status, has_new_commits=has_new_commits
+            )
+            if status_string:
+                text += f"*{repo_info.name}*: {status_string}\n"
+            else:
+                no_news.append(repo_info.name)
+
+        if no_news:
+            text += f"Nothing new for {', '.join(no_news)}"
+
+        await self.say_with_attachment(
+            channel_id=command_args.channel_id,
+            title=f"Release statuses:",
+            text=text,
+        )
+
     async def needs_review(self, command_args):
         """
         Print out what PRs need review
@@ -1211,6 +1223,13 @@ class Bot:
                 command_func=self.publish,
                 description="Publish a package to PyPI or NPM",
                 supported_project_types=[LIBRARY_TYPE],
+            ),
+            Command(
+                command="status",
+                parsers=[],
+                command_func=self.status,
+                description="Show the status of repos managed by doof",
+                supported_project_types=None,
             ),
             Command(
                 command="hi",

--- a/bot.py
+++ b/bot.py
@@ -1058,7 +1058,7 @@ class Bot:
 
         await self.say_with_attachment(
             channel_id=command_args.channel_id,
-            title=f"Release statuses:",
+            title="Release statuses:",
             text=text,
         )
 

--- a/bot_test.py
+++ b/bot_test.py
@@ -23,8 +23,6 @@ from constants import (
     RC,
     SETUPTOOLS,
     NPM,
-    WAITING_FOR_CHECKBOXES,
-    FREEZE_RELEASE,
 )
 from exception import ReleaseException
 from github import get_org_and_repo
@@ -135,11 +133,11 @@ def mock_labels(mocker):
 
     _label = None
 
-    def _set_label(*args, label, **kwargs):
+    def _set_label(*args, label, **kwargs):  # pylint: disable=unused-argument
         nonlocal _label
         _label = label
 
-    def _get_label(*args, **kwargs):
+    def _get_label(*args, **kwargs):  # pylint: disable=unused-argument
         return _label
 
     mock_set = mocker.async_patch("bot.set_release_label", side_effect=_set_label)
@@ -389,7 +387,9 @@ async def test_hash(doof, test_repo, mocker, deployment_server_type, expected_ur
 
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize("command", ["release", "start release"])
-async def test_release(doof, test_repo, mocker, command, mock_labels):
+async def test_release(
+    doof, test_repo, mocker, command, mock_labels
+):  # pylint: disable=unused-argument
     """
     Doof should do a release when asked
     """
@@ -448,7 +448,7 @@ async def test_release(doof, test_repo, mocker, command, mock_labels):
 # pylint: disable=too-many-locals
 async def test_hotfix_release(
     doof, test_repo, test_repo_directory, mocker, mock_labels
-):
+):  # pylint: disable=unused-argument
     """
     Doof should do a hotfix when asked
     """
@@ -634,7 +634,9 @@ async def test_release_library(doof, library_test_repo, mocker):
 
 
 @pytest.mark.parametrize("project_type", [WEB_APPLICATION_TYPE, LIBRARY_TYPE])
-async def test_finish_release(doof, mocker, project_type, mock_labels):
+async def test_finish_release(
+    doof, mocker, project_type, mock_labels
+):  # pylint: disable=unused-argument
     """
     Doof should finish a release when asked
     """
@@ -728,7 +730,7 @@ async def test_webhook_different_callback_id(doof, mocker):
 # pylint: disable=too-many-arguments
 async def test_webhook_finish_release(
     doof, mocker, test_repo, library_test_repo, mock_labels
-):
+):  # pylint: disable=unused-argument
     """
     Finish the release
     """
@@ -1019,7 +1021,7 @@ async def test_help(doof):
 @pytest.mark.parametrize("has_checkboxes", [True, False])
 async def test_wait_for_checkboxes(
     mocker, doof, test_repo, has_checkboxes, mock_labels
-):
+):  # pylint: disable=unused-argument
     """wait_for_checkboxes should poll github, parse checkboxes and see if all are checked"""
     org, repo = get_org_and_repo(test_repo.repo_url)
     channel_id = test_repo.channel_id
@@ -1155,7 +1157,9 @@ async def test_startup(doof, mocker, repo_info, has_release_pr, has_expected):
         assert run_release_lifecycle_mock.called is False
 
 
-async def test_wait_for_deploy_rc(doof, test_repo, mocker, mock_labels):
+async def test_wait_for_deploy_rc(
+    doof, test_repo, mocker, mock_labels
+):  # pylint: disable=unused-argument
     """Bot._wait_for_deploy_prod should wait until repo has been deployed to RC"""
     wait_for_deploy_mock = mocker.async_patch("bot.wait_for_deploy")
     org, repo = get_org_and_repo(test_repo.repo_url)
@@ -1195,7 +1199,9 @@ async def test_wait_for_deploy_rc(doof, test_repo, mocker, mock_labels):
     )
 
 
-async def test_wait_for_deploy_prod(doof, test_repo, mocker, mock_labels):
+async def test_wait_for_deploy_prod(
+    doof, test_repo, mocker, mock_labels
+):  # pylint: disable=unused-argument
     """Bot._wait_for_deploy_prod should wait until repo has been deployed to production"""
     wait_for_deploy_mock = mocker.async_patch("bot.wait_for_deploy")
     version = "1.2.345"

--- a/bot_test.py
+++ b/bot_test.py
@@ -64,7 +64,6 @@ class DoofSpoof(Bot):
 
         self.slack_users = []
         self.messages = {}
-        self.labels = {}
 
     async def lookup_users(self):
         """Users in the channel"""
@@ -123,17 +122,29 @@ class DoofSpoof(Bot):
             f"Expected {text} to be said {times} time(s) but was said {match_count} times."
         )
 
-    async def _set_release_label(self, *, repo_url, pr_number, label):
-        self.labels[(repo_url, pr_number)] = label
-
-    async def _get_release_label(self, *, repo_url, pr_number):
-        return self.labels.get((repo_url, pr_number))
-
 
 @pytest.fixture
 def doof(event_loop):
     """Create a Doof"""
     yield DoofSpoof(loop=event_loop)
+
+
+@pytest.fixture
+def mock_labels(mocker):
+    """mock out setting and getting labels"""
+
+    _label = None
+
+    def _set_label(*args, label, **kwargs):
+        nonlocal _label
+        _label = label
+
+    def _get_label(*args, **kwargs):
+        return _label
+
+    mock_set = mocker.async_patch("bot.set_release_label", side_effect=_set_label)
+    mock_get = mocker.async_patch("bot.status_for_repo_last_pr", side_effect=_get_label)
+    yield mock_set, mock_get
 
 
 async def test_release_notes(doof, test_repo, test_repo_directory, mocker):
@@ -153,7 +164,11 @@ async def test_release_notes(doof, test_repo, test_repo_directory, mocker):
     any_new_commits_mock = mocker.async_patch("bot.any_new_commits", return_value=True)
     org, repo = get_org_and_repo(test_repo.repo_url)
     release_pr = ReleasePR(
-        "version", f"https://github.com/{org}/{repo}/pulls/123456", "body", 123456
+        "version",
+        f"https://github.com/{org}/{repo}/pulls/123456",
+        "body",
+        123456,
+        False,
     )
     get_release_pr_mock = mocker.async_patch(
         "bot.get_release_pr", return_value=release_pr
@@ -374,7 +389,7 @@ async def test_hash(doof, test_repo, mocker, deployment_server_type, expected_ur
 
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize("command", ["release", "start release"])
-async def test_release(doof, test_repo, mocker, command):
+async def test_release(doof, test_repo, mocker, command, mock_labels):
     """
     Doof should do a release when asked
     """
@@ -384,6 +399,7 @@ async def test_release(doof, test_repo, mocker, command):
         url="http://new.url",
         body="Release PR body",
         number=123,
+        open=False,
     )
     get_release_pr_mock = mocker.async_patch(
         "bot.get_release_pr", side_effect=[None, pr, pr]
@@ -430,7 +446,9 @@ async def test_release(doof, test_repo, mocker, command):
 
 
 # pylint: disable=too-many-locals
-async def test_hotfix_release(doof, test_repo, test_repo_directory, mocker):
+async def test_hotfix_release(
+    doof, test_repo, test_repo_directory, mocker, mock_labels
+):
     """
     Doof should do a hotfix when asked
     """
@@ -445,6 +463,7 @@ async def test_hotfix_release(doof, test_repo, test_repo_directory, mocker):
         url="http://new.url",
         body="Release PR body",
         number=123,
+        open=False,
     )
     get_release_pr_mock = mocker.async_patch(
         "bot.get_release_pr", side_effect=[None, pr, pr]
@@ -510,6 +529,7 @@ async def test_release_in_progress(doof, test_repo, mocker, command):
             url=url,
             body="Release PR body",
             number=123,
+            open=False,
         ),
     )
 
@@ -563,6 +583,7 @@ async def test_release_library(doof, library_test_repo, mocker):
         url="http://new.url",
         body="Release PR body",
         number=123,
+        open=False,
     )
     get_release_pr_mock = mocker.async_patch(
         "bot.get_release_pr", side_effect=[None, pr, pr]
@@ -613,7 +634,7 @@ async def test_release_library(doof, library_test_repo, mocker):
 
 
 @pytest.mark.parametrize("project_type", [WEB_APPLICATION_TYPE, LIBRARY_TYPE])
-async def test_finish_release(doof, mocker, project_type):
+async def test_finish_release(doof, mocker, project_type, mock_labels):
     """
     Doof should finish a release when asked
     """
@@ -623,6 +644,7 @@ async def test_finish_release(doof, mocker, project_type):
         url="http://new.url",
         body="Release PR body",
         number=123,
+        open=False,
     )
     get_release_pr_mock = mocker.async_patch("bot.get_release_pr", return_value=pr)
     finish_release_mock = mocker.async_patch("bot.finish_release")
@@ -704,7 +726,9 @@ async def test_webhook_different_callback_id(doof, mocker):
 
 
 # pylint: disable=too-many-arguments
-async def test_webhook_finish_release(doof, mocker, test_repo, library_test_repo):
+async def test_webhook_finish_release(
+    doof, mocker, test_repo, library_test_repo, mock_labels
+):
     """
     Finish the release
     """
@@ -715,6 +739,7 @@ async def test_webhook_finish_release(doof, mocker, test_repo, library_test_repo
         url="url",
         body="body",
         number=123,
+        open=False,
     )
     get_release_pr_mock = mocker.async_patch("bot.get_release_pr", return_value=pr_body)
     finish_release_mock = mocker.async_patch("bot.finish_release")
@@ -992,13 +1017,19 @@ async def test_help(doof):
 
 
 @pytest.mark.parametrize("has_checkboxes", [True, False])
-async def test_wait_for_checkboxes(mocker, doof, test_repo, has_checkboxes):
+async def test_wait_for_checkboxes(
+    mocker, doof, test_repo, has_checkboxes, mock_labels
+):
     """wait_for_checkboxes should poll github, parse checkboxes and see if all are checked"""
     org, repo = get_org_and_repo(test_repo.repo_url)
     channel_id = test_repo.channel_id
 
     pr = ReleasePR(
-        "version", f"https://github.com/{org}/{repo}/pulls/123456", "body", 123456
+        "version",
+        f"https://github.com/{org}/{repo}/pulls/123456",
+        "body",
+        123456,
+        False,
     )
     get_release_pr_mock = mocker.async_patch("bot.get_release_pr", return_value=pr)
     get_unchecked_patch = mocker.async_patch(
@@ -1093,6 +1124,7 @@ async def test_startup(doof, mocker, repo_info, has_release_pr, has_expected):
         url=repo_info.repo_url,
         body="Release PR body",
         number=123,
+        open=False,
     )
     org, repo = get_org_and_repo(repo_info.repo_url)
     get_release_pr_mock = mocker.async_patch(
@@ -1123,12 +1155,16 @@ async def test_startup(doof, mocker, repo_info, has_release_pr, has_expected):
         assert run_release_lifecycle_mock.called is False
 
 
-async def test_wait_for_deploy_rc(doof, test_repo, mocker):
+async def test_wait_for_deploy_rc(doof, test_repo, mocker, mock_labels):
     """Bot._wait_for_deploy_prod should wait until repo has been deployed to RC"""
     wait_for_deploy_mock = mocker.async_patch("bot.wait_for_deploy")
     org, repo = get_org_and_repo(test_repo.repo_url)
     release_pr = ReleasePR(
-        "version", f"https://github.com/{org}/{repo}/pulls/123456", "body", 123456
+        "version",
+        f"https://github.com/{org}/{repo}/pulls/123456",
+        "body",
+        123456,
+        False,
     )
     authors = {"author1", "author2"}
     get_unchecked = mocker.async_patch(
@@ -1159,7 +1195,7 @@ async def test_wait_for_deploy_rc(doof, test_repo, mocker):
     )
 
 
-async def test_wait_for_deploy_prod(doof, test_repo, mocker):
+async def test_wait_for_deploy_prod(doof, test_repo, mocker, mock_labels):
     """Bot._wait_for_deploy_prod should wait until repo has been deployed to production"""
     wait_for_deploy_mock = mocker.async_patch("bot.wait_for_deploy")
     version = "1.2.345"
@@ -1168,7 +1204,7 @@ async def test_wait_for_deploy_prod(doof, test_repo, mocker):
     )
     channel_id = test_repo.channel_id
     release_pr = ReleasePR(
-        "version", "https://github.com/org/repo/pulls/123456", "body", 123456
+        "version", "https://github.com/org/repo/pulls/123456", "body", 123456, False
     )
 
     await doof._wait_for_deploy_prod(  # pylint: disable=protected-access
@@ -1329,7 +1365,11 @@ async def test_start_new_releases(
     get_release_pr_mock = mocker.async_patch(
         "bot.get_release_pr",
         return_value=ReleasePR(
-            version=old_version, url="https://example.com", body="...", number=123
+            version=old_version,
+            url="https://example.com",
+            body="...",
+            number=123,
+            open=False,
         )
         if has_release_pr
         else None,
@@ -1396,40 +1436,31 @@ async def test_start_new_releases(
         assert doof.said("No new releases needed", channel_id=command_args.channel_id)
 
 
-async def test_set_release_label(doof, mocker, test_repo):
-    """_set_release_label should call github to set a release label"""
-    set_label_mock = mocker.async_patch("bot.set_release_label")
-    await Bot._set_release_label(  # pylint: disable=protected-access
-        doof,
-        repo_url=test_repo.repo_url,
-        pr_number=123,
-        label=WAITING_FOR_CHECKBOXES,
+async def test_status(doof, mocker, test_repo, library_test_repo):
+    """The status command should list statuses for each repo"""
+    status_last_pr_mock = mocker.async_patch("bot.status_for_repo_last_pr")
+    status_new_commits_mock = mocker.async_patch("bot.status_for_repo_new_commits")
+    description_text = "description"
+    format_status_mock = mocker.patch(
+        "bot.format_status_for_repo", side_effect=[description_text, ""]
     )
-    set_label_mock.assert_called_once_with(
-        github_access_token=GITHUB_ACCESS,
-        repo_url=test_repo.repo_url,
-        pr_number=123,
-        label=WAITING_FOR_CHECKBOXES,
+    await doof.run_command(
+        manager="mitodl_user",
+        channel_id="not_a_repo_channel",
+        words=["status"],
     )
-
-
-@pytest.mark.parametrize(
-    "github_labels, expected_label",
-    [
-        [[WAITING_FOR_CHECKBOXES, FREEZE_RELEASE, "other"], None],
-        [[WAITING_FOR_CHECKBOXES, "other"], WAITING_FOR_CHECKBOXES],
-        [["other"], None],
-    ],
-)
-async def test_get_release_label(
-    doof, mocker, test_repo, github_labels, expected_label
-):
-    """_get_release_label should get a release label if one exists, or None"""
-    get_label_mock = mocker.async_patch("bot.get_labels", return_value=github_labels)
-    label = await Bot._get_release_label(  # pylint: disable=protected-access
-        doof, repo_url=test_repo.repo_url, pr_number=123
-    )
-    assert label == expected_label
-    get_label_mock.assert_called_once_with(
-        repo_url=test_repo.repo_url, github_access_token=GITHUB_ACCESS, pr_number=123
-    )
+    assert doof.said(f"*{test_repo.name}*: {description_text}")
+    assert doof.said(f"Nothing new for {library_test_repo.name}")
+    for repo_info in [test_repo, library_test_repo]:
+        status_last_pr_mock.assert_any_call(
+            github_access_token=GITHUB_ACCESS,
+            repo_info=repo_info,
+        )
+        status_new_commits_mock.assert_any_call(
+            github_access_token=GITHUB_ACCESS,
+            repo_info=repo_info,
+        )
+        format_status_mock.assert_any_call(
+            current_status=status_last_pr_mock.return_value,
+            has_new_commits=status_new_commits_mock.return_value,
+        )

--- a/conftest.py
+++ b/conftest.py
@@ -102,7 +102,9 @@ def library_test_repo_directory():
 @pytest.fixture
 def library_test_repo(library_test_repo_directory):
     """Initialize the library test repo from the gzipped file"""
-    with open(os.path.join(library_test_repo_directory, "setup.py"), "w") as f:
+    with open(
+        os.path.join(library_test_repo_directory, "setup.py"), "w", encoding="utf-8"
+    ) as f:
         # Hacky way to convert a web application project to a library
         f.write(SETUP_PY)
 

--- a/constants.py
+++ b/constants.py
@@ -38,6 +38,7 @@ GIT_RELEASE_NOTES_PATH = os.path.join(
 )
 YARN_PATH = os.path.join(SCRIPT_DIR, "./node_modules/.bin/yarn")
 
+# github labels
 ALL_CHECKBOXES_CHECKED = "all checkboxes checked"
 DEPLOYING_TO_RC = "deploying to rc"
 WAITING_FOR_CHECKBOXES = "waiting for checkboxes"
@@ -51,3 +52,25 @@ RELEASE_LABELS = [
     DEPLOYED_TO_PROD,
 ]
 FREEZE_RELEASE = "freeze release"
+BLOCKER = "blocker"
+BLOCKED = "blocked"
+RELEASE_BLOCKER = "release blocker"
+BLOCKER_LABELS = [
+    FREEZE_RELEASE,
+    BLOCKED,
+    BLOCKER,
+    RELEASE_BLOCKER,
+]
+
+# not github labels but used internally when calculating release statuses
+LIBRARY_PR_WAITING_FOR_MERGE = "library PR waiting for merge"
+
+STATUS_EMOJIS = {
+    WAITING_FOR_CHECKBOXES: "🕰️",
+    DEPLOYING_TO_PROD: "🕰️",
+    DEPLOYING_TO_RC: "🕰️",
+    ALL_CHECKBOXES_CHECKED: "🔔",
+    LIBRARY_PR_WAITING_FOR_MERGE: "🔔",
+}
+for label in BLOCKER_LABELS:
+    STATUS_EMOJIS[label] = "❌"

--- a/finish_release.py
+++ b/finish_release.py
@@ -54,10 +54,10 @@ async def set_release_date(version, timezone, *, root):
     await check_call(["git", "fetch", "--tags"], cwd=root)
     await check_call(["git", "checkout", "release-candidate"], cwd=root)
 
-    with open(release_filename) as f:
+    with open(release_filename, "r", encoding="utf-8") as f:
         existing_note_lines = f.readlines()
 
-    with open(release_filename, "w") as f:
+    with open(release_filename, "w", encoding="utf-8") as f:
         for line in existing_note_lines:
             if line.startswith("Version ") and "Released" not in line:
                 version_match = re.search(r"[0-9\.]+", line)

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -150,7 +150,9 @@ async def test_set_release_date(test_repo_directory, timezone, mocker):
         root=test_repo_directory,
     )
     await set_release_date("0.2.0", timezone, root=test_repo_directory)
-    with open(os.path.join(test_repo_directory, "RELEASE.rst"), "r") as release_file:
+    with open(
+        os.path.join(test_repo_directory, "RELEASE.rst"), "r", encoding="utf-8"
+    ) as release_file:
         content = release_file.read()
     assert re.search(r"Version 0.1.0 \(Released April 27, 2018\)", content) is not None
     today = datetime.now().strftime("%B %d, %Y")

--- a/github_test.py
+++ b/github_test.py
@@ -25,7 +25,11 @@ pytestmark = pytest.mark.asyncio
 
 async def test_needs_review(mocker):
     """Assert behavior of needs review"""
-    with open(os.path.join(SCRIPT_DIR, "test_needs_review_response.json")) as f:
+    with open(
+        os.path.join(SCRIPT_DIR, "test_needs_review_response.json"),
+        "r",
+        encoding="utf-8",
+    ) as f:
         payload = json.load(f)
     github_access_token = "token"
 

--- a/lib.py
+++ b/lib.py
@@ -27,7 +27,7 @@ from github import (
 from repo_info import RepoInfo
 
 
-ReleasePR = namedtuple("ReleasePR", ["version", "url", "body", "number"])
+ReleasePR = namedtuple("ReleasePR", ["version", "url", "body", "number", "open"])
 
 
 VERSION_RE = r"\d+\.\d+\.\d+"
@@ -112,6 +112,7 @@ async def get_release_pr(*, github_access_token, org, repo, all_prs=False):
         number=pr["number"],
         body=pr["body"],
         url=pr["html_url"],
+        open=pr["state"] == "open",
     )
 
 

--- a/lib.py
+++ b/lib.py
@@ -315,7 +315,7 @@ def load_repos_info(channel_lookup):
     Returns:
         list of RepoInfo: Information about the repositories
     """
-    with open(os.path.join(SCRIPT_DIR, "repos_info.json")) as f:
+    with open(os.path.join(SCRIPT_DIR, "repos_info.json"), "r", encoding="utf-8") as f:
         repos_info = json.load(f)
 
     infos = [

--- a/lib_test.py
+++ b/lib_test.py
@@ -117,6 +117,7 @@ async def test_get_unchecked_authors(mocker):
             version="1.2.3",
             url="http://url",
             number=234,
+            open=False,
         ),
     )
     unchecked = await get_unchecked_authors(

--- a/publish.py
+++ b/publish.py
@@ -86,7 +86,7 @@ async def upload_to_npm(*, project_dir, npm_token):
         project_dir (str): The project directory
         npm_token (str): A token to access the npm registry
     """
-    with open(Path(project_dir) / ".npmrc", "w") as f:
+    with open(Path(project_dir) / ".npmrc", "w", encoding="utf-8") as f:
         f.write(f"//registry.npmjs.org/:_authToken={npm_token}")
 
     await check_call(["npm", "install", "--production=false"], cwd=project_dir)

--- a/publish_test.py
+++ b/publish_test.py
@@ -64,7 +64,7 @@ async def test_upload_to_npm(mocker, test_repo_directory, library_test_repo):
 
     def _call(command, *, cwd, **kwargs):
         """check that the token was written correctly"""
-        with open(Path(cwd) / ".npmrc") as f:
+        with open(Path(cwd) / ".npmrc", "r", encoding="utf-8") as f:
             assert f.read() == f"//registry.npmjs.org/:_authToken={npm_token}"
 
         recorded_commands.append(command)

--- a/release.py
+++ b/release.py
@@ -115,12 +115,12 @@ async def update_release_notes(old_version, new_version, *, base_branch, root):
 
     release_filename = os.path.join(root, "RELEASE.rst")
     try:
-        with open(release_filename) as f:
+        with open(release_filename, "r", encoding="utf-8") as f:
             existing_note_lines = f.readlines()
     except FileNotFoundError:
         existing_note_lines = []
 
-    with open(release_filename, "w") as f:
+    with open(release_filename, "w", encoding="utf-8") as f:
         f.write("Release Notes\n")
         f.write("=============\n")
         f.write("\n")

--- a/release_test.py
+++ b/release_test.py
@@ -1,4 +1,3 @@
-# pylint: disable=consider-using-with
 """Tests for release script"""
 import os
 from subprocess import CalledProcessError
@@ -241,9 +240,12 @@ async def test_update_release_notes(test_repo_directory):
         "0.3.0", "0.4.0", base_branch="master", root=test_repo_directory
     )
 
-    assert (
-        open(os.path.join(test_repo_directory, "RELEASE.rst")).read()
-        == """Release Notes
+    with open(
+        os.path.join(test_repo_directory, "RELEASE.rst"), "r", encoding="utf-8"
+    ) as f:
+        assert (
+            f.read()
+            == """Release Notes
 =============
 
 Version 0.4.0
@@ -285,7 +287,7 @@ Version 0.1.0
 
 - Initial release
 """
-    )
+        )
 
 
 async def test_update_release_notes_initial(test_repo_directory):
@@ -300,9 +302,12 @@ async def test_update_release_notes_initial(test_repo_directory):
         "0.2.0", "0.3.0", base_branch="master", root=test_repo_directory
     )
 
-    assert (
-        open(os.path.join(test_repo_directory, "RELEASE.rst")).read()
-        == """Release Notes
+    with open(
+        os.path.join(test_repo_directory, "RELEASE.rst"), "r", encoding="utf-8"
+    ) as f:
+        assert (
+            f.read()
+            == """Release Notes
 =============
 
 Version 0.3.0
@@ -311,7 +316,7 @@ Version 0.3.0
 - A commit between 2 and 3
 
 """
-    )
+        )
 
 
 async def test_verify_new_commits(test_repo_directory):

--- a/status.py
+++ b/status.py
@@ -101,7 +101,7 @@ def format_status_for_repo(*, current_status, has_new_commits):
         current_status (str): The status of the most recent PR for the repo
         has_new_commits (bool): Whether there are new commits to release
     """
-    new_status_string = f"*new commits*" if has_new_commits else ""
+    new_status_string = "*new commits*" if has_new_commits else ""
     current_status_string = (
         current_status if current_status and current_status != DEPLOYED_TO_PROD else ""
     )

--- a/status.py
+++ b/status.py
@@ -1,0 +1,109 @@
+"""Get release status of a repository"""
+from constants import (
+    BLOCKER_LABELS,
+    DEPLOYED_TO_PROD,
+    LIBRARY_TYPE,
+    LIBRARY_PR_WAITING_FOR_MERGE,
+    RELEASE_LABELS,
+    STATUS_EMOJIS,
+)
+from github import (
+    get_labels,
+    get_org_and_repo,
+)
+from lib import (
+    get_default_branch,
+    get_release_pr,
+    init_working_dir,
+)
+from release import any_new_commits
+from version import get_project_version
+
+
+async def status_for_repo_last_pr(*, github_access_token, repo_info):
+    """
+    Calculate release status for the most recent PR
+
+    The return value will be one of:
+
+      ALL_CHECKBOXES_CHECKED - All checkboxes are checked off and the release is ready to merge
+      DEPLOYED_TO_PROD - The release has been successfully deployed to production
+      DEPLOYING_TO_PROD - The release is in the process of being deployed to production
+      DEPLOYING_TO_RC - The pull request is in the middle of deploying to RC
+      FREEZE_RELEASE - The release is frozen, so it should be ignored until that github label is removed
+      LIBRARY_WAITING_FOR_RELEASE - There is a release PR for a library, waiting on the release manager to merge
+      WAITING_FOR_CHECKBOXES - The bot is polling regularly to check if all checkboxes are checked off
+
+    Or None if there is no previous release, or something unexpected happened.
+
+    Args:
+        github_access_token (str): The github access token
+        repo_info (RepoInfo): Repository info
+
+    Returns:
+        str or None: A status string
+    """
+    org, repo = get_org_and_repo(repo_info.repo_url)
+    release_pr = await get_release_pr(
+        github_access_token=github_access_token,
+        org=org,
+        repo=repo,
+        all_prs=True,
+    )
+    if release_pr:
+        if repo_info.project_type == LIBRARY_TYPE:
+            if release_pr.open:
+                return LIBRARY_PR_WAITING_FOR_MERGE
+        else:
+            labels = {
+                label.lower()
+                for label in await get_labels(
+                    github_access_token=github_access_token,
+                    repo_url=repo_info.repo_url,
+                    pr_number=release_pr.number,
+                )
+            }
+            # BLOCKER_LABELS must go first so it overrides other labels
+            for label in [*BLOCKER_LABELS, *RELEASE_LABELS]:
+                if label.lower() in labels:
+                    return label
+
+    return None
+
+
+async def status_for_repo_new_commits(*, github_access_token, repo_info):
+    """
+    Check if there are new commits to be part of a release
+
+    Args:
+        github_access_token (str): The github access token
+        repo_info (RepoInfo): Repository info
+
+    Returns:
+        bool:
+            Whether or not there are new commits
+    """
+    async with init_working_dir(github_access_token, repo_info.repo_url) as working_dir:
+        last_version = await get_project_version(
+            repo_info=repo_info, working_dir=working_dir
+        )
+        default_branch = await get_default_branch(working_dir)
+        return await any_new_commits(
+            last_version, base_branch=default_branch, root=working_dir
+        )
+
+
+def format_status_for_repo(*, current_status, has_new_commits):
+    """
+    Adds formatting to render a status
+
+    Args:
+        current_status (str): The status of the most recent PR for the repo
+        has_new_commits (bool): Whether there are new commits to release
+    """
+    new_status_string = f"*new commits*" if has_new_commits else ""
+    current_status_string = (
+        current_status if current_status and current_status != DEPLOYED_TO_PROD else ""
+    )
+    emoji = STATUS_EMOJIS.get(current_status, "")
+    return f"{current_status_string}{emoji} {new_status_string}".strip()

--- a/status.py
+++ b/status.py
@@ -66,7 +66,7 @@ async def status_for_repo_last_pr(*, github_access_token, repo_info):
             # BLOCKER_LABELS must go first so it overrides other labels
             for label in [*BLOCKER_LABELS, *RELEASE_LABELS]:
                 if label.lower() in labels:
-                    return label
+                    return label.lower()
 
     return None
 

--- a/status_test.py
+++ b/status_test.py
@@ -1,0 +1,162 @@
+"""Tests for statuses"""
+import pytest
+
+
+from constants import (
+    ALL_CHECKBOXES_CHECKED,
+    BLOCKED,
+    BLOCKER,
+    BLOCKER_LABELS,
+    DEPLOYING_TO_RC,
+    DEPLOYING_TO_PROD,
+    DEPLOYED_TO_PROD,
+    FREEZE_RELEASE,
+    LIBRARY_PR_WAITING_FOR_MERGE,
+    RELEASE_BLOCKER,
+    RELEASE_LABELS,
+    WAITING_FOR_CHECKBOXES,
+)
+from github import get_org_and_repo
+from lib import ReleasePR
+from status import (
+    status_for_repo_last_pr,
+    status_for_repo_new_commits,
+    format_status_for_repo,
+)
+from test_util import (
+    async_context_manager_yielder,
+)
+
+
+pytestmark = pytest.mark.asyncio
+GITHUB_TOKEN = "github-token"
+
+
+@pytest.mark.parametrize(
+    "has_new_commits, status, expected",
+    [
+        [True, None, f"*new commits*"],
+        [False, None, f""],
+        [True, ALL_CHECKBOXES_CHECKED, f"{ALL_CHECKBOXES_CHECKED}🔔 *new commits*"],
+        [False, ALL_CHECKBOXES_CHECKED, f"{ALL_CHECKBOXES_CHECKED}🔔"],
+        [True, DEPLOYED_TO_PROD, f"*new commits*"],
+        [False, DEPLOYED_TO_PROD, f""],
+        [True, DEPLOYING_TO_PROD, f"{DEPLOYING_TO_PROD}🕰️ *new commits*"],
+        [False, DEPLOYING_TO_PROD, f"{DEPLOYING_TO_PROD}🕰️"],
+        [True, DEPLOYING_TO_RC, f"{DEPLOYING_TO_RC}🕰️ *new commits*"],
+        [False, DEPLOYING_TO_RC, f"{DEPLOYING_TO_RC}🕰️"],
+        [True, FREEZE_RELEASE, f"{FREEZE_RELEASE}❌ *new commits*"],
+        [False, FREEZE_RELEASE, f"{FREEZE_RELEASE}❌"],
+        [True, BLOCKED, f"{BLOCKED}❌ *new commits*"],
+        [False, BLOCKED, f"{BLOCKED}❌"],
+        [True, BLOCKER, f"{BLOCKER}❌ *new commits*"],
+        [False, BLOCKER, f"{BLOCKER}❌"],
+        [True, RELEASE_BLOCKER, f"{RELEASE_BLOCKER}❌ *new commits*"],
+        [False, RELEASE_BLOCKER, f"{RELEASE_BLOCKER}❌"],
+        [
+            True,
+            LIBRARY_PR_WAITING_FOR_MERGE,
+            f"{LIBRARY_PR_WAITING_FOR_MERGE}🔔 *new commits*",
+        ],
+        [False, LIBRARY_PR_WAITING_FOR_MERGE, f"{LIBRARY_PR_WAITING_FOR_MERGE}🔔"],
+        [True, WAITING_FOR_CHECKBOXES, f"{WAITING_FOR_CHECKBOXES}🕰️ *new commits*"],
+        [False, WAITING_FOR_CHECKBOXES, f"{WAITING_FOR_CHECKBOXES}🕰️"],
+    ],
+)
+def test_format_status_for_repo(has_new_commits, status, expected):
+    """format_status_for_repo should create an appropriate description given a status and if there are new commits"""
+    assert (
+        format_status_for_repo(current_status=status, has_new_commits=has_new_commits)
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "has_release_pr, is_library_project, is_open, labels, expected",
+    [
+        [False, False, False, [], None],
+        [True, True, True, [], LIBRARY_PR_WAITING_FOR_MERGE],
+        [True, True, False, [], None],
+        [True, False, False, [], None],
+        [True, False, False, [WAITING_FOR_CHECKBOXES, BLOCKED], BLOCKED],
+        [True, False, False, [BLOCKED, WAITING_FOR_CHECKBOXES], BLOCKED],
+        *[
+            [True, False, False, [label], label]
+            for label in [*BLOCKER_LABELS, *RELEASE_LABELS]
+        ],
+    ],
+)
+async def test_status_for_repo_last_pr(
+    mocker,
+    test_repo,
+    library_test_repo,
+    has_release_pr,
+    is_library_project,
+    is_open,
+    labels,
+    expected,
+):
+    """status_for_repo_last_pr should get the status for the most recent PR for a project"""
+    release_pr = ReleasePR("1.2.3", "http://example.com", "body", 12, is_open)
+    get_release_pr_mock = mocker.async_patch(
+        "status.get_release_pr", return_value=release_pr if has_release_pr else None
+    )
+    get_labels_mock = mocker.async_patch("status.get_labels", return_value=labels)
+
+    repo_info = library_test_repo if is_library_project else test_repo
+    org, repo = get_org_and_repo(repo_info.repo_url)
+    assert (
+        await status_for_repo_last_pr(
+            github_access_token=GITHUB_TOKEN, repo_info=repo_info
+        )
+        == expected
+    )
+
+    get_release_pr_mock.assert_called_once_with(
+        github_access_token=GITHUB_TOKEN,
+        org=org,
+        repo=repo,
+        all_prs=True,
+    )
+    if not is_library_project and has_release_pr:
+        get_labels_mock.assert_called_once_with(
+            github_access_token=GITHUB_TOKEN,
+            repo_url=repo_info.repo_url,
+            pr_number=release_pr.number,
+        )
+    else:
+        assert get_labels_mock.called is False
+
+
+@pytest.mark.parametrize("has_commits", [True, False])
+async def test_status_for_repo_new_commits(
+    mocker, test_repo, test_repo_directory, has_commits
+):
+    """status_for_repo_new_commits should check if there are new commits"""
+    init_mock = mocker.patch(
+        "status.init_working_dir",
+        side_effect=async_context_manager_yielder(test_repo_directory),
+    )
+    get_project_version_mock = mocker.async_patch("status.get_project_version")
+    get_default_branch_mock = mocker.async_patch("status.get_default_branch")
+    new_commits_mock = mocker.async_patch(
+        "status.any_new_commits", return_value=has_commits
+    )
+    assert (
+        await status_for_repo_new_commits(
+            github_access_token=GITHUB_TOKEN,
+            repo_info=test_repo,
+        )
+        == has_commits
+    )
+
+    init_mock.assert_called_once_with(GITHUB_TOKEN, test_repo.repo_url)
+    get_project_version_mock.assert_called_once_with(
+        repo_info=test_repo, working_dir=test_repo_directory
+    )
+    get_default_branch_mock.assert_called_once_with(test_repo_directory)
+    new_commits_mock.assert_called_once_with(
+        get_project_version_mock.return_value,
+        base_branch=get_default_branch_mock.return_value,
+        root=test_repo_directory,
+    )

--- a/status_test.py
+++ b/status_test.py
@@ -35,12 +35,12 @@ GITHUB_TOKEN = "github-token"
 @pytest.mark.parametrize(
     "has_new_commits, status, expected",
     [
-        [True, None, f"*new commits*"],
-        [False, None, f""],
+        [True, None, "*new commits*"],
+        [False, None, ""],
         [True, ALL_CHECKBOXES_CHECKED, f"{ALL_CHECKBOXES_CHECKED}🔔 *new commits*"],
         [False, ALL_CHECKBOXES_CHECKED, f"{ALL_CHECKBOXES_CHECKED}🔔"],
-        [True, DEPLOYED_TO_PROD, f"*new commits*"],
-        [False, DEPLOYED_TO_PROD, f""],
+        [True, DEPLOYED_TO_PROD, "*new commits*"],
+        [False, DEPLOYED_TO_PROD, ""],
         [True, DEPLOYING_TO_PROD, f"{DEPLOYING_TO_PROD}🕰️ *new commits*"],
         [False, DEPLOYING_TO_PROD, f"{DEPLOYING_TO_PROD}🕰️"],
         [True, DEPLOYING_TO_RC, f"{DEPLOYING_TO_RC}🕰️ *new commits*"],
@@ -95,7 +95,7 @@ async def test_status_for_repo_last_pr(
     is_open,
     labels,
     expected,
-):
+):  # pylint: disable=too-many-arguments
     """status_for_repo_last_pr should get the status for the most recent PR for a project"""
     release_pr = ReleasePR("1.2.3", "http://example.com", "body", 12, is_open)
     get_release_pr_mock = mocker.async_patch(

--- a/test_constants.py
+++ b/test_constants.py
@@ -17,6 +17,7 @@ OTHER_PR = {
     "body": "not a release",
     "title": "not a release",
     "head": {"ref": "other-branch"},
+    "state": "open",
     "number": 345,
 }
 RELEASE_PR = {
@@ -26,4 +27,5 @@ RELEASE_PR = {
     "title": "Release 0.53.3",
     "head": {"ref": "release-candidate"},
     "number": 234,
+    "state": "open",
 }

--- a/version.py
+++ b/version.py
@@ -72,7 +72,7 @@ def update_python_version_in_file(*, root, filename, new_version, readonly):
     file_lines = []
     update_count = 0
     old_version = None
-    with open(version_filepath) as f:
+    with open(version_filepath, "r", encoding="utf-8") as f:
         for line in f.readlines():
             line = line.strip("\n")
             updated_line = line
@@ -108,7 +108,7 @@ def update_python_version_in_file(*, root, filename, new_version, readonly):
     if update_count == 1:
         # Replace contents of file with updated version
         if not readonly:
-            with open(version_filepath, "w") as f:
+            with open(version_filepath, "w", encoding="utf-8") as f:
                 for line in file_lines:
                     f.write(line)
         return old_version
@@ -188,7 +188,7 @@ async def update_npm_version(*, new_version, working_dir, readonly):
             The old version which has been successfully replaced with the new version.
             On error, an exception will raise.
     """
-    with open(Path(working_dir) / "package.json", "r") as f:
+    with open(Path(working_dir) / "package.json", "r", encoding="utf-8") as f:
         old_version = json.load(f)["version"]
     if not readonly:
         await check_output(
@@ -214,10 +214,10 @@ async def update_version_file(*, new_version, working_dir, readonly):
     old_version = None
     version_file = Path(working_dir) / "VERSION"
     if version_file.is_file():
-        with open(version_file, "r") as f:
+        with open(version_file, "r", encoding="utf-8") as f:
             old_version = f.readline().strip()
         if not readonly:
-            with open(version_file, "w") as f:
+            with open(version_file, "w", encoding="utf-8") as f:
                 f.write(new_version)
     return old_version
 

--- a/version_test.py
+++ b/version_test.py
@@ -1,4 +1,3 @@
-# pylint: disable=consider-using-with
 """Test version functions"""
 import json
 import os
@@ -40,7 +39,8 @@ async def test_update_python_version_settings(test_repo, test_repo_directory, re
     new_version = "9.9.99"
     path = os.path.join(test_repo_directory, "ccxcon/settings.py")
 
-    old_lines = open(path).readlines()
+    with open(path, "r", encoding="utf-8") as f:
+        old_lines = f.readlines()
 
     old_version = await update_version(
         repo_info=test_repo,
@@ -49,7 +49,8 @@ async def test_update_python_version_settings(test_repo, test_repo_directory, re
         readonly=readonly,
     )
     assert old_version == "0.2.0"
-    new_lines = open(path).readlines()
+    with open(path, "r", encoding="utf-8") as f:
+        new_lines = f.readlines()
 
     assert len(old_lines) == len(new_lines)
 
@@ -61,7 +62,7 @@ async def test_update_python_version_settings(test_repo, test_repo_directory, re
     assert diff_count == (0 if readonly else 1)
 
     found_new_version = False
-    with open(path) as f:
+    with open(path, "r", encoding="utf-8") as f:
         for line in f.readlines():
             if line == 'VERSION = "{}"\n'.format(new_version):
                 found_new_version = True
@@ -75,7 +76,9 @@ async def test_update_python_version_init(test_repo_directory, test_repo, readon
     old_version = "1.2.3"
     test_repo_directory = Path(test_repo_directory)
     os.unlink(test_repo_directory / "ccxcon" / "settings.py")
-    with open(test_repo_directory / "ccxcon" / "__init__.py", "w") as f:
+    with open(
+        test_repo_directory / "ccxcon" / "__init__.py", "w", encoding="utf-8"
+    ) as f:
         f.write("__version__ = '{}'".format(old_version))
     new_version = "4.5.6"
     assert (
@@ -89,7 +92,9 @@ async def test_update_python_version_init(test_repo_directory, test_repo, readon
     )
 
     found_new_version = False
-    with open(test_repo_directory / "ccxcon" / "__init__.py") as f:
+    with open(
+        test_repo_directory / "ccxcon" / "__init__.py", "r", encoding="utf-8"
+    ) as f:
         for line in f.readlines():
             if line.strip() == f'__version__ = "{new_version}"':
                 found_new_version = True
@@ -102,7 +107,9 @@ async def test_update_python_version_setup(test_repo_directory, test_repo, reado
     """If we detect a version in setup.py we should update it properly, if readonly is set"""
     old_version = "0.2.0"
     os.unlink(os.path.join(test_repo_directory, "ccxcon/settings.py"))
-    with open(os.path.join(test_repo_directory, "setup.py"), "w") as f:
+    with open(
+        os.path.join(test_repo_directory, "setup.py"), "w", encoding="utf-8"
+    ) as f:
         f.write(
             """
 setup(
@@ -125,7 +132,9 @@ setup(
     )
 
     found_new_version = False
-    with open(os.path.join(test_repo_directory, "setup.py")) as f:
+    with open(
+        os.path.join(test_repo_directory, "setup.py"), "r", encoding="utf-8"
+    ) as f:
         for line in f.readlines():
             if line.strip() == "version='{}',".format(new_version):
                 found_new_version = True
@@ -141,7 +150,9 @@ async def test_update_python_version_missing(test_repo_directory, test_repo, rea
 setup(
     name='pylmod',
 )        """
-    with open(os.path.join(test_repo_directory, "setup.py"), "w") as f:
+    with open(
+        os.path.join(test_repo_directory, "setup.py"), "w", encoding="utf-8"
+    ) as f:
         f.write(contents)
     with pytest.raises(UpdateVersionException) as ex:
         await update_version(
@@ -163,7 +174,9 @@ setup(
     name='pylmod',
     version='1.2.3',
 )        """
-    with open(os.path.join(test_repo_directory, "setup.py"), "w") as f:
+    with open(
+        os.path.join(test_repo_directory, "setup.py"), "w", encoding="utf-8"
+    ) as f:
         f.write(contents)
     with pytest.raises(UpdateVersionException) as ex:
         await update_version(
@@ -189,7 +202,9 @@ setup(
     version='1.2.3',
     version='4.5.6',
 )        """
-    with open(os.path.join(test_repo_directory, "setup.py"), "w") as f:
+    with open(
+        os.path.join(test_repo_directory, "setup.py"), "w", encoding="utf-8"
+    ) as f:
         f.write(contents)
     with pytest.raises(UpdateVersionException) as ex:
         await update_version(
@@ -248,14 +263,14 @@ async def test_update_python_version_in_file(filename, line, expected_output, re
     new_version = "0.123.456"
     with TemporaryDirectory() as base:
         path = Path(base) / filename
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write("text")
         retrieved_version = update_python_version_in_file(
             root=base, filename=filename, new_version=new_version, readonly=readonly
         )
         assert retrieved_version is None
 
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(line)
 
         retrieved_version = update_python_version_in_file(
@@ -263,7 +278,7 @@ async def test_update_python_version_in_file(filename, line, expected_output, re
         )
         assert retrieved_version == old_version
 
-        with open(path) as f:
+        with open(path, "r", encoding="utf-8") as f:
             lines = f.readlines()
 
         if readonly:
@@ -281,14 +296,14 @@ async def test_update_npm_version(readonly):
 
     with TemporaryDirectory() as working_dir:
         package_json_path = Path(working_dir) / "package.json"
-        with open(package_json_path, "w") as f:
+        with open(package_json_path, "w", encoding="utf-8") as f:
             json.dump({"version": old_version}, f)
 
         received = await update_npm_version(
             new_version=new_version, working_dir=working_dir, readonly=readonly
         )
         assert received == old_version
-        with open(package_json_path) as f:
+        with open(package_json_path, "r", encoding="utf-8") as f:
             assert json.load(f) == {"version": old_version if readonly else new_version}
 
 
@@ -300,14 +315,14 @@ async def test_update_version_file(readonly):
 
     with TemporaryDirectory() as working_dir:
         version_file_path = Path(working_dir) / "VERSION"
-        with open(version_file_path, "w") as f:
+        with open(version_file_path, "w", encoding="utf-8") as f:
             f.write(f"{old_version}\n")
 
         received = await update_version_file(
             new_version=new_version, working_dir=working_dir, readonly=readonly
         )
         assert received == old_version
-        with open(version_file_path) as f:
+        with open(version_file_path, "r", encoding="utf-8") as f:
             assert f.readline().strip() == old_version if readonly else new_version
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #327 

#### What's this PR do?
Adds a command to output status information for all repositories

#### How should this be manually tested?
Run `python bot_local.py bots status` in the console and check that the output makes sense to you.

#### Screenshots
![Screenshot from 2021-08-31 13-02-59](https://user-images.githubusercontent.com/863262/131545540-78ce5513-5515-4d0f-be38-85b3cb90bfd1.png)
