### PR TITLE
Report new commits since release-candidate for status command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -320,7 +320,9 @@ class Bot:
             release_pr (ReleasePR): Release pull request
         """
         status = await status_for_repo_last_pr(
-            repo_info=repo_info, github_access_token=self.github_access_token
+            repo_info=repo_info,
+            github_access_token=self.github_access_token,
+            release_pr=release_pr,
         )
 
         # In general these functions should put things in this order:
@@ -1028,13 +1030,22 @@ class Bot:
         no_news = []
         text = ""
         for repo_info in sorted_repos_info:
+            org, repo = get_org_and_repo(repo_info.repo_url)
+            release_pr = await get_release_pr(
+                github_access_token=self.github_access_token,
+                org=org,
+                repo=repo,
+                all_prs=True,
+            )
             status = await status_for_repo_last_pr(
                 github_access_token=self.github_access_token,
                 repo_info=repo_info,
+                release_pr=release_pr,
             )
             has_new_commits = await status_for_repo_new_commits(
                 github_access_token=self.github_access_token,
                 repo_info=repo_info,
+                release_pr=release_pr,
             )
             status_string = format_status_for_repo(
                 current_status=status, has_new_commits=has_new_commits

--- a/bot_test.py
+++ b/bot_test.py
@@ -1475,6 +1475,10 @@ async def test_status(doof, mocker, test_repo, library_test_repo):
     """The status command should list statuses for each repo"""
     status_last_pr_mock = mocker.async_patch("bot.status_for_repo_last_pr")
     status_new_commits_mock = mocker.async_patch("bot.status_for_repo_new_commits")
+    release_pr = ReleasePR("1.2.3", "http://example.com", "body", 12, True)
+    get_release_pr_mock = mocker.async_patch(
+        "bot.get_release_pr", return_value=release_pr
+    )
     description_text = "description"
     format_status_mock = mocker.patch(
         "bot.format_status_for_repo", side_effect=[description_text, ""]
@@ -1490,12 +1494,18 @@ async def test_status(doof, mocker, test_repo, library_test_repo):
         status_last_pr_mock.assert_any_call(
             github_access_token=GITHUB_ACCESS,
             repo_info=repo_info,
+            release_pr=release_pr,
         )
         status_new_commits_mock.assert_any_call(
             github_access_token=GITHUB_ACCESS,
             repo_info=repo_info,
+            release_pr=release_pr,
         )
         format_status_mock.assert_any_call(
             current_status=status_last_pr_mock.return_value,
             has_new_commits=status_new_commits_mock.return_value,
+        )
+        org, repo = get_org_and_repo(repo_info.repo_url)
+        get_release_pr_mock.assert_any_call(
+            github_access_token=GITHUB_ACCESS, org=org, repo=repo, all_prs=True
         )

--- a/status.py
+++ b/status.py
@@ -8,13 +8,9 @@ from constants import (
     STATUS_EMOJIS,
     WAITING_FOR_CHECKBOXES,
 )
-from github import (
-    get_labels,
-    get_org_and_repo,
-)
+from github import get_labels
 from lib import (
     get_default_branch,
-    get_release_pr,
     init_working_dir,
 )
 from release import any_new_commits

--- a/status.py
+++ b/status.py
@@ -21,7 +21,7 @@ from release import any_new_commits
 from version import get_project_version
 
 
-async def status_for_repo_last_pr(*, github_access_token, repo_info):
+async def status_for_repo_last_pr(*, github_access_token, repo_info, release_pr):
     """
     Calculate release status for the most recent PR
 
@@ -40,17 +40,11 @@ async def status_for_repo_last_pr(*, github_access_token, repo_info):
     Args:
         github_access_token (str): The github access token
         repo_info (RepoInfo): Repository info
+        release_pr (ReleasePR): The info for the release PR
 
     Returns:
         str or None: A status string
     """
-    org, repo = get_org_and_repo(repo_info.repo_url)
-    release_pr = await get_release_pr(
-        github_access_token=github_access_token,
-        org=org,
-        repo=repo,
-        all_prs=True,
-    )
     if release_pr:
         if repo_info.project_type == LIBRARY_TYPE:
             if release_pr.open:
@@ -80,13 +74,14 @@ async def status_for_repo_last_pr(*, github_access_token, repo_info):
     return None
 
 
-async def status_for_repo_new_commits(*, github_access_token, repo_info):
+async def status_for_repo_new_commits(*, github_access_token, repo_info, release_pr):
     """
     Check if there are new commits to be part of a release
 
     Args:
         github_access_token (str): The github access token
         repo_info (RepoInfo): Repository info
+        release_pr (ReleasePR): The info for the release PR
 
     Returns:
         bool:
@@ -98,7 +93,11 @@ async def status_for_repo_new_commits(*, github_access_token, repo_info):
         )
         default_branch = await get_default_branch(working_dir)
         return await any_new_commits(
-            last_version, base_branch=default_branch, root=working_dir
+            last_version,
+            base_branch="release-candidate"
+            if release_pr and release_pr.open
+            else default_branch,
+            root=working_dir,
         )
 
 

--- a/status_test.py
+++ b/status_test.py
@@ -16,7 +16,6 @@ from constants import (
     RELEASE_LABELS,
     WAITING_FOR_CHECKBOXES,
 )
-from github import get_org_and_repo
 from lib import ReleasePR
 from status import (
     status_for_repo_last_pr,
@@ -127,7 +126,7 @@ async def test_status_for_repo_last_pr(
 @pytest.mark.parametrize("has_commits", [True, False])
 @pytest.mark.parametrize("has_release_pr", [True, False])
 @pytest.mark.parametrize("is_open", [True, False])
-async def test_status_for_repo_new_commits(
+async def test_status_for_repo_new_commits(  # pylint: disable=too-many-arguments
     mocker, test_repo, test_repo_directory, has_commits, has_release_pr, is_open
 ):
     """status_for_repo_new_commits should check if there are new commits"""

--- a/status_test.py
+++ b/status_test.py
@@ -99,27 +99,21 @@ async def test_status_for_repo_last_pr(
     expected,
 ):  # pylint: disable=too-many-arguments
     """status_for_repo_last_pr should get the status for the most recent PR for a project"""
-    release_pr = ReleasePR("1.2.3", "http://example.com", "body", 12, is_open)
-    get_release_pr_mock = mocker.async_patch(
-        "status.get_release_pr", return_value=release_pr if has_release_pr else None
+    release_pr = (
+        ReleasePR("1.2.3", "http://example.com", "body", 12, is_open)
+        if has_release_pr
+        else None
     )
     get_labels_mock = mocker.async_patch("status.get_labels", return_value=labels)
 
     repo_info = library_test_repo if is_library_project else test_repo
-    org, repo = get_org_and_repo(repo_info.repo_url)
     assert (
         await status_for_repo_last_pr(
-            github_access_token=GITHUB_TOKEN, repo_info=repo_info
+            github_access_token=GITHUB_TOKEN, repo_info=repo_info, release_pr=release_pr
         )
         == expected
     )
 
-    get_release_pr_mock.assert_called_once_with(
-        github_access_token=GITHUB_TOKEN,
-        org=org,
-        repo=repo,
-        all_prs=True,
-    )
     if not is_library_project and has_release_pr:
         get_labels_mock.assert_called_once_with(
             github_access_token=GITHUB_TOKEN,
@@ -131,10 +125,17 @@ async def test_status_for_repo_last_pr(
 
 
 @pytest.mark.parametrize("has_commits", [True, False])
+@pytest.mark.parametrize("has_release_pr", [True, False])
+@pytest.mark.parametrize("is_open", [True, False])
 async def test_status_for_repo_new_commits(
-    mocker, test_repo, test_repo_directory, has_commits
+    mocker, test_repo, test_repo_directory, has_commits, has_release_pr, is_open
 ):
     """status_for_repo_new_commits should check if there are new commits"""
+    release_pr = (
+        ReleasePR("1.2.3", "http://example.com", "body", 12, is_open)
+        if has_release_pr
+        else None
+    )
     init_mock = mocker.patch(
         "status.init_working_dir",
         side_effect=async_context_manager_yielder(test_repo_directory),
@@ -148,6 +149,7 @@ async def test_status_for_repo_new_commits(
         await status_for_repo_new_commits(
             github_access_token=GITHUB_TOKEN,
             repo_info=test_repo,
+            release_pr=release_pr,
         )
         == has_commits
     )
@@ -159,6 +161,8 @@ async def test_status_for_repo_new_commits(
     get_default_branch_mock.assert_called_once_with(test_repo_directory)
     new_commits_mock.assert_called_once_with(
         get_project_version_mock.return_value,
-        base_branch=get_default_branch_mock.return_value,
+        base_branch="release-candidate"
+        if has_release_pr and is_open
+        else get_default_branch_mock.return_value,
         root=test_repo_directory,
     )


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #354 

#### What's this PR do?
Currently the status command shows the "new commits" message when there are new commits, whether or not there is already a release PR open. This PR changes that so that it will show the "new commits" message if there are any new commits and there is no release PR, or if there are new commits on main since the last release PR.