### PR TITLE
Fix status command to handle new commits

### DIFF
--- a/exception.py
+++ b/exception.py
@@ -22,6 +22,10 @@ class VersionMismatchException(Exception):
     """Error if the version is unexpected"""
 
 
+class StatusException(Exception):
+    """Error if something happened when calculating the status"""
+
+
 class AsyncCalledProcessError(CalledProcessError):
     """Extend CalledProcessError to print the stdout as well"""
 

--- a/release.py
+++ b/release.py
@@ -63,8 +63,25 @@ async def any_new_commits(version, *, base_branch, root):
     Returns:
         bool: True if there are new commits
     """
+    return await any_commits_between_branches(
+        branch1=f"v{version}", branch2=base_branch, root=root
+    )
+
+
+async def any_commits_between_branches(*, branch1, branch2, root):
+    """
+    Return true if there are any commits between two branches
+
+    Args:
+        branch1 (str): The first branch to compare against
+        branch2 (str): The second, more recent branch to compare against
+        root (str): The project root directory
+
+    Returns:
+        bool: True if there are new commits
+    """
     output = await check_output(
-        ["git", "rev-list", "--count", f"v{version}..{base_branch}", "--"], cwd=root
+        ["git", "rev-list", "--count", f"{branch1}..{branch2}", "--"], cwd=root
     )
     return int(output) != 0
 

--- a/status.py
+++ b/status.py
@@ -13,7 +13,7 @@ from lib import (
     get_default_branch,
     init_working_dir,
 )
-from release import any_new_commits
+from release import any_commits_between_branches
 from version import get_project_version
 
 
@@ -88,11 +88,11 @@ async def status_for_repo_new_commits(*, github_access_token, repo_info, release
             repo_info=repo_info, working_dir=working_dir
         )
         default_branch = await get_default_branch(working_dir)
-        return await any_new_commits(
-            last_version,
-            base_branch="release-candidate"
+        return await any_commits_between_branches(
+            branch1="origin/release-candidate"
             if release_pr and release_pr.open
-            else default_branch,
+            else f"v{last_version}",
+            branch2=default_branch,
             root=working_dir,
         )
 

--- a/status_test.py
+++ b/status_test.py
@@ -141,8 +141,8 @@ async def test_status_for_repo_new_commits(  # pylint: disable=too-many-argument
     )
     get_project_version_mock = mocker.async_patch("status.get_project_version")
     get_default_branch_mock = mocker.async_patch("status.get_default_branch")
-    new_commits_mock = mocker.async_patch(
-        "status.any_new_commits", return_value=has_commits
+    any_commits_mock = mocker.async_patch(
+        "status.any_commits_between_branches", return_value=has_commits
     )
     assert (
         await status_for_repo_new_commits(
@@ -158,10 +158,10 @@ async def test_status_for_repo_new_commits(  # pylint: disable=too-many-argument
         repo_info=test_repo, working_dir=test_repo_directory
     )
     get_default_branch_mock.assert_called_once_with(test_repo_directory)
-    new_commits_mock.assert_called_once_with(
-        get_project_version_mock.return_value,
-        base_branch="release-candidate"
+    any_commits_mock.assert_called_once_with(
+        branch1="origin/release-candidate"
         if has_release_pr and is_open
-        else get_default_branch_mock.return_value,
+        else f"v{get_project_version_mock.return_value}",
+        branch2=get_default_branch_mock.return_value,
         root=test_repo_directory,
     )


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #356 

#### What's this PR do?
Fixes a bug I introduced in #356. To detect new commits we need to compare between `release-candidate` and `main` if there is a release open, or between the latest released version and `main` if there is not. 

#### How should this be manually tested?
 - Create a virtualenv for this script and install `requirements.txt` in it
 - Set values for some environment variables using values from heroku. The only values you need are `SLACK_ACCESS_TOKEN`, `BOT_ACCESS_TOKEN`, and `GITHUB_ACCESS_TOKEN`. The rest can be fake values for testing this PR
 - Run `python bot_local.py doofs-house status` and verify that the output looks roughly correct

