### PR TITLE
Support per-project versioning strategies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pylint *.py
 
       - name: Black
-        run: black . --check
+        run: black --version && black . --check
 
       - name: Tests
         run: pytest . && coverage xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 package-lock.json
 node_modules/
 .envrc
+.python-version

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,8 @@ from constants import (
     DJANGO,
     LIBRARY_TYPE,
     NPM,
+    PYTHON_VERSION,
+    NPM_VERSION,
     SETUPTOOLS,
     WEB_APPLICATION_TYPE,
 )
@@ -51,6 +53,7 @@ WEB_TEST_REPO_INFO = RepoInfo(
     project_type=WEB_APPLICATION_TYPE,
     web_application_type=DJANGO,
     packaging_tool=None,
+    versioning_strategy=PYTHON_VERSION,
 )
 
 
@@ -78,6 +81,7 @@ NPM_TEST_REPO_INFO = RepoInfo(
     project_type=LIBRARY_TYPE,
     packaging_tool=NPM,
     web_application_type=None,
+    versioning_strategy=NPM_VERSION,
 )
 LIBRARY_TEST_REPO_INFO = RepoInfo(
     name="lib_repo",
@@ -89,6 +93,7 @@ LIBRARY_TEST_REPO_INFO = RepoInfo(
     project_type=LIBRARY_TYPE,
     packaging_tool=SETUPTOOLS,
     web_application_type=None,
+    versioning_strategy=PYTHON_VERSION,
 )
 
 

--- a/constants.py
+++ b/constants.py
@@ -22,6 +22,12 @@ SETUPTOOLS = "setuptools"
 GO = "go"
 VALID_PACKAGING_TOOL_TYPES = [NONE, NPM, SETUPTOOLS, GO]
 
+# versioning strategies
+FILE_VERSION = "file"
+NPM_VERSION = "npm"
+PYTHON_VERSION = "python"
+VALID_VERSIONING_STRATEGIES = [FILE_VERSION, NPM_VERSION, PYTHON_VERSION]
+
 # deployment server types
 RC = "rc"
 CI = "ci"

--- a/lib.py
+++ b/lib.py
@@ -13,10 +13,12 @@ from dateutil.parser import parse
 
 from async_subprocess import check_call, check_output
 from constants import (
+    FILE_VERSION,
     SCRIPT_DIR,
     LIBRARY_TYPE,
     WEB_APPLICATION_TYPE,
     VALID_PACKAGING_TOOL_TYPES,
+    VALID_VERSIONING_STRATEGIES,
     VALID_WEB_APPLICATION_TYPES,
 )
 from exception import ReleaseException
@@ -233,7 +235,7 @@ def url_with_access_token(github_access_token, repo_url):
     """
     Inserts the access token into the URL
 
-    Returns:
+    Returns:FILE_VERSION
         str: The URL formatted with an access token
     """
     org, repo = get_org_and_repo(repo_url)
@@ -337,6 +339,7 @@ def load_repos_info(channel_lookup):
             project_type=repo_info.get("project_type"),
             web_application_type=repo_info.get("web_application_type"),
             packaging_tool=repo_info.get("packaging_tool"),
+            versioning_strategy=repo_info.get("versioning_strategy", FILE_VERSION),
         )
         for repo_info in repos_info["repos"]
         if repo_info.get("repo_url")
@@ -354,6 +357,10 @@ def load_repos_info(channel_lookup):
                 raise Exception(
                     f"Unexpected packaging tool {info.packaging_tool} for {info.name}"
                 )
+        if info.versioning_strategy not in VALID_VERSIONING_STRATEGIES:
+            raise Exception(
+                f"Unexpected versioning strategy {info.versioning_strategy} for {info.name}"
+            )
 
     return infos
 

--- a/lib_test.py
+++ b/lib_test.py
@@ -4,8 +4,12 @@ import pytest
 
 from constants import (
     DJANGO,
+    FILE_VERSION,
     LIBRARY_TYPE,
+    NONE,
     NPM,
+    NPM_VERSION,
+    PYTHON_VERSION,
     WEB_APPLICATION_TYPE,
 )
 from lib import (
@@ -188,6 +192,7 @@ async def test_load_repos_info(mocker):
                     "channel_name": "bootcamp-eng",
                     "project_type": WEB_APPLICATION_TYPE,
                     "web_application_type": DJANGO,
+                    "versioning_strategy": PYTHON_VERSION,
                 },
                 {
                     "name": "bootcamp-ecommerce-library",
@@ -195,6 +200,15 @@ async def test_load_repos_info(mocker):
                     "channel_name": "bootcamp-library",
                     "project_type": LIBRARY_TYPE,
                     "packaging_tool": NPM,
+                    "versioning_strategy": NPM_VERSION,
+                },
+                {
+                    "name": "ocw-hugo-projects",
+                    "repo_url": "https://github.com/mitodl/ocw-hugo-projects.git",
+                    "channel_name": "ocw-hugo-projects",
+                    "project_type": "library",
+                    "packaging_tool": "none",
+                    "versioning_strategy": FILE_VERSION,
                 },
             ]
         },
@@ -210,8 +224,9 @@ async def test_load_repos_info(mocker):
         project_type=WEB_APPLICATION_TYPE,
         web_application_type=DJANGO,
         packaging_tool=None,
+        versioning_strategy=PYTHON_VERSION,
     )
-    expected_library = RepoInfo(
+    expected_npm_library = RepoInfo(
         name="bootcamp-ecommerce-library",
         repo_url="https://github.com/mitodl/bootcamp-ecommerce-library.git",
         ci_hash_url=None,
@@ -221,6 +236,19 @@ async def test_load_repos_info(mocker):
         project_type=LIBRARY_TYPE,
         web_application_type=None,
         packaging_tool=NPM,
+        versioning_strategy=NPM_VERSION,
+    )
+    expected_file_library = RepoInfo(
+        name="ocw-hugo-projects",
+        repo_url="https://github.com/mitodl/ocw-hugo-projects.git",
+        ci_hash_url=None,
+        rc_hash_url=None,
+        prod_hash_url=None,
+        channel_id="ocw_hugo_channel_id",
+        project_type=LIBRARY_TYPE,
+        web_application_type=None,
+        packaging_tool=NONE,
+        versioning_strategy=FILE_VERSION,
     )
 
     assert (
@@ -228,9 +256,10 @@ async def test_load_repos_info(mocker):
             {
                 "bootcamp-eng": "bootcamp_channel_id",
                 "bootcamp-library": "bootcamp_library_channel_id",
+                "ocw-hugo-projects": "ocw_hugo_channel_id",
             }
         )
-        == [expected_web_application, expected_library]
+        == [expected_web_application, expected_npm_library, expected_file_library]
     )
     assert json_load.call_count == 1
 

--- a/repo_info.py
+++ b/repo_info.py
@@ -13,5 +13,6 @@ RepoInfo = namedtuple(
         "project_type",
         "web_application_type",
         "packaging_tool",
+        "versioning_strategy",
     ],
 )

--- a/repos_info.json
+++ b/repos_info.json
@@ -8,7 +8,8 @@
       "prod_hash_url": "https://micromasters.mit.edu/static/hash.txt",
       "channel_name": "micromasters-eng",
       "project_type": "web_application",
-      "web_application_type": "django"
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     },
     {
       "name": "bootcamp-ecommerce",
@@ -18,7 +19,8 @@
       "prod_hash_url": "https://bootcamp.odl.mit.edu/static/hash.txt",
       "channel_name": "bootcamp-eng",
       "project_type": "web_application",
-      "web_application_type": "django"
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     },
     {
       "name": "open-discussions",
@@ -28,7 +30,8 @@
       "prod_hash_url": "https://discussions.odl.mit.edu/static/hash.txt",
       "channel_name": "mit-open-eng",
       "project_type": "web_application",
-      "web_application_type": "django"
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     },
     {
       "name": "mitxpro",
@@ -38,7 +41,8 @@
       "prod_hash_url": "https://xpro.mit.edu/static/hash.txt",
       "channel_name": "mitxpro-eng",
       "project_type": "web_application",
-      "web_application_type": "django"
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     },
     {
       "name": "odl-video-service",
@@ -48,70 +52,80 @@
       "prod_hash_url": "https://video.odl.mit.edu/static/hash.txt",
       "channel_name": "odl-video-service-eng",
       "project_type": "web_application",
-      "web_application_type": "django"
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     },
     {
       "name": "edx-sga",
       "repo_url": "https://github.com/mitodl/edx-sga.git",
       "channel_name": "edx-sga-doof",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "edx-sysadmin",
       "repo_url": "https://github.com/mitodl/edx-sysadmin.git",
       "channel_name": "edx-sysadmin",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "rapid-response-xblock",
       "repo_url": "https://github.com/mitodl/rapid-response-xblock.git",
       "channel_name": "rapid-response-doof",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "open-discussions-client",
       "repo_url": "https://github.com/mitodl/open-discussions-client.git",
       "channel_name": "discussions-client",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "edx-api-client",
       "repo_url": "https://github.com/mitodl/edx-api-client.git",
       "channel_name": "edx-api-client-doof",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "mit-moira",
       "repo_url": "https://github.com/mitodl/mit-moira.git",
       "channel_name": "mit-moira",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "ocw-data-parser",
       "repo_url": "https://github.com/mitodl/ocw-data-parser.git",
       "channel_name": "ocw-data-parser",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "django-server-status",
       "repo_url": "https://github.com/mitodl/django-server-status.git",
       "channel_name": "django-server-status",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "ocw-to-hugo",
       "repo_url": "https://github.com/mitodl/ocw-to-hugo.git",
       "channel_name": "ocw-to-hugo",
       "project_type": "library",
-      "packaging_tool": "npm"
+      "packaging_tool": "npm",
+      "versioning_strategy": "npm"
     },
     {
       "name": "ocw-www",
@@ -121,7 +135,8 @@
       "web_application_type": "hugo",
       "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-www-hash.txt",
       "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-www-hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-www-hash.txt"
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-www-hash.txt",
+      "versioning_strategy": "npm"
     },
     {
       "name": "ocw-studio",
@@ -131,7 +146,8 @@
       "web_application_type": "django",
       "ci_hash_url": "https://ocw-studio-ci.odl.mit.edu/static/hash.txt",
       "rc_hash_url": "https://ocw-studio-rc.odl.mit.edu/static/hash.txt",
-      "prod_hash_url": "https://ocw-studio.odl.mit.edu/static/hash.txt"
+      "prod_hash_url": "https://ocw-studio.odl.mit.edu/static/hash.txt",
+      "versioning_strategy": "python"
     },
     {
       "name": "ocw-hugo-themes",
@@ -141,28 +157,32 @@
       "web_application_type": "hugo",
       "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-hugo-themes-hash.txt",
       "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-hugo-themes-hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-hugo-themes-hash.txt"
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-hugo-themes-hash.txt",
+      "versioning_strategy": "npm"
     },
     {
       "name": "ocw-hugo-projects",
       "repo_url": "https://github.com/mitodl/ocw-hugo-projects.git",
       "channel_name": "ocw-hugo-projects",
       "project_type": "library",
-      "packaging_tool": "none"
+      "packaging_tool": "none",
+      "versioning_strategy": "file"
     },
     {
       "name": "course-search-utils",
       "repo_url": "https://github.com/mitodl/course-search-utils.git",
       "channel_name": "course-search-utils",
       "project_type": "library",
-      "packaging_tool": "npm"
+      "packaging_tool": "npm",
+      "versioning_strategy": "npm"
     },
     {
       "name": "edx-username-changer",
       "repo_url": "https://github.com/mitodl/edx-username-changer.git",
       "channel_name": "edx-username-changer-doof",
       "project_type": "library",
-      "packaging_tool": "setuptools"
+      "packaging_tool": "setuptools",
+      "versioning_strategy": "python"
     },
     {
       "name": "mitxonline",
@@ -172,7 +192,8 @@
       "prod_hash_url": "https://mitxonline.mit.edu/static/hash.txt",
       "channel_name": "mitxonline-eng",
       "project_type": "web_application",
-      "web_application_type": "django"
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     }
   ]
 }

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-black
+black==21.9b0
 codecov
 pdbpp
 pylint

--- a/version.py
+++ b/version.py
@@ -8,13 +8,9 @@ import re
 
 from async_subprocess import check_output
 from constants import (
-    DJANGO,
-    HUGO,
-    LIBRARY_TYPE,
-    NONE,
-    NPM,
-    SETUPTOOLS,
-    WEB_APPLICATION_TYPE,
+    FILE_VERSION,
+    NPM_VERSION,
+    PYTHON_VERSION,
 )
 from exception import UpdateVersionException
 from lib import init_working_dir, VERSION_RE
@@ -244,25 +240,15 @@ async def update_version(*, repo_info, new_version, working_dir, readonly):
             The old version which has been successfully replaced with the new version.
             On failure, an exception will be raised.
     """
-    if repo_info.project_type == WEB_APPLICATION_TYPE:
-        if repo_info.web_application_type == DJANGO:
-            return update_python_version(
-                new_version=new_version, working_dir=working_dir, readonly=readonly
-            )
-        elif repo_info.web_application_type == HUGO:
-            return await update_npm_version(
-                new_version=new_version, working_dir=working_dir, readonly=readonly
-            )
-    elif repo_info.project_type == LIBRARY_TYPE:
-        if repo_info.packaging_tool == SETUPTOOLS:
-            return update_python_version(
-                new_version=new_version, working_dir=working_dir, readonly=readonly
-            )
-        elif repo_info.packaging_tool == NPM:
-            return await update_npm_version(
-                new_version=new_version, working_dir=working_dir, readonly=readonly
-            )
-        elif repo_info.packaging_tool == NONE:
-            return await update_version_file(
-                new_version=new_version, working_dir=working_dir, readonly=readonly
-            )
+    if repo_info.versioning_strategy == PYTHON_VERSION:
+        return update_python_version(
+            new_version=new_version, working_dir=working_dir, readonly=readonly
+        )
+    elif repo_info.versioning_strategy == NPM_VERSION:
+        return await update_npm_version(
+            new_version=new_version, working_dir=working_dir, readonly=readonly
+        )
+    elif repo_info.versioning_strategy == FILE_VERSION:
+        return await update_version_file(
+            new_version=new_version, working_dir=working_dir, readonly=readonly
+        )

--- a/version_test.py
+++ b/version_test.py
@@ -7,13 +7,9 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from constants import (
-    DJANGO,
-    HUGO,
-    LIBRARY_TYPE,
-    NONE,
-    NPM,
-    SETUPTOOLS,
-    WEB_APPLICATION_TYPE,
+    FILE_VERSION,
+    NPM_VERSION,
+    PYTHON_VERSION,
 )
 from repo_info import RepoInfo
 from version import (
@@ -329,21 +325,17 @@ async def test_update_version_file(readonly):
 # pylint: disable=too-many-arguments
 @pytest.mark.parametrize("readonly", [True, False])
 @pytest.mark.parametrize(
-    "project_type, packaging_tool, web_application_type, expected_python, expected_js, expected_version_file",
+    "versioning_strategy, expected_python, expected_js, expected_version_file",
     [
-        [WEB_APPLICATION_TYPE, None, DJANGO, True, False, False],
-        [WEB_APPLICATION_TYPE, None, HUGO, False, True, False],
-        [LIBRARY_TYPE, SETUPTOOLS, None, True, False, False],
-        [LIBRARY_TYPE, NPM, None, False, True, False],
-        [LIBRARY_TYPE, NONE, None, False, False, True],
+        [PYTHON_VERSION, True, False, False],
+        [NPM_VERSION, False, True, False],
+        [FILE_VERSION, False, False, True],
     ],
 )
 async def test_update_version(
     mocker,
     test_repo,
-    project_type,
-    packaging_tool,
-    web_application_type,
+    versioning_strategy,
     expected_python,
     expected_js,
     expected_version_file,
@@ -353,9 +345,7 @@ async def test_update_version(
     repo_info = RepoInfo(
         **{
             **test_repo._asdict(),
-            "project_type": project_type,
-            "packaging_tool": packaging_tool,
-            "web_application_type": web_application_type,
+            "versioning_strategy": versioning_strategy,
         }
     )
     new_version = "12.34.56"


### PR DESCRIPTION
#### What are the relevant tickets?
Support for changes requested in https://github.com/mitodl/micromasters/pull/5118#discussion_r756265456

#### What's this PR do?
This makes the versioning strategy explicit in the `RepoInfo` data so that we can support `VERSION` files for django web applications.

#### How should this be manually tested?
Tests should pass