### PR TITLE
remove ocw-www and update ocw-hugo-themes hash urls

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -128,17 +128,6 @@
       "versioning_strategy": "npm"
     },
     {
-      "name": "ocw-www",
-      "repo_url": "https://github.com/mitodl/ocw-www.git",
-      "channel_name": "ocw-www",
-      "project_type": "web_application",
-      "web_application_type": "hugo",
-      "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-www-hash.txt",
-      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-www-hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-www-hash.txt",
-      "versioning_strategy": "npm"
-    },
-    {
       "name": "ocw-studio",
       "repo_url": "https://github.com/mitodl/ocw-studio.git",
       "channel_name": "ocw-studio",
@@ -155,9 +144,9 @@
       "channel_name": "ocw-hugo-themes",
       "project_type": "web_application",
       "web_application_type": "hugo",
-      "ci_hash_url": "https://ocw-next.netlify.app/static/ocw-hugo-themes-hash.txt",
-      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/ocw-hugo-themes-hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/ocw-hugo-themes-hash.txt",
+      "ci_hash_url": "https://ocw-next.netlify.app/static/hash.txt",
+      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/hash.txt",
       "versioning_strategy": "npm"
     },
     {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/release-script/issues/360

#### What's this PR do?
This PR removes the reference to https://github.com/mitodl/ocw-www as this content is now managed by `ocw-studio` and the manually managed repo is not needed anymore.  The hash file locations for `ocw-hugo-themes` were also updated to reflect where they are now published by the Concourse build pipelines.

#### How should this be manually tested?
No way to manually test this, we just have to merge it and try it out.
