### PR TITLE
update ocw urls

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -137,8 +137,8 @@
       "project_type": "web_application",
       "web_application_type": "hugo",
       "ci_hash_url": "https://ocw-next.netlify.app/static/hash.txt",
-      "rc_hash_url": "https://ocwnext-rc.odl.mit.edu/static/hash.txt",
-      "prod_hash_url": "https://ocwnext.odl.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://live-qa.ocw.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://ocw.mit.edu/static/hash.txt",
       "versioning_strategy": "npm"
     },
     {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
The ocw-hugo-themes release failed because https://ocwnext.odl.mit.edu/ no longer exists. This fixes the issues

#### How should this be manually tested?
Check that you can go to both the  the new urls 

