### PR TITLE
Fix channel name for open-discussions

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -28,7 +28,7 @@
       "ci_hash_url": "https://discussions-ci.odl.mit.edu/static/hash.txt",
       "rc_hash_url": "https://discussions-rc.odl.mit.edu/static/hash.txt",
       "prod_hash_url": "https://discussions.odl.mit.edu/static/hash.txt",
-      "channel_name": "product-mit-open",
+      "channel_name": "doof-open-discussions",
       "project_type": "web_application",
       "web_application_type": "django",
       "versioning_strategy": "python"


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
The slack channel got renamed, so this updates the configuration to point to the correct one.

#### How should this be manually tested?
Not practical, just check that the channel name matches.