### PR TITLE
add mit-open-login-button

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -186,6 +186,14 @@
       "project_type": "web_application",
       "web_application_type": "django",
       "versioning_strategy": "python"
+    },
+    {
+      "name": "mit-open-login-button",
+      "repo_url": "https://github.com/mitodl/mit-open-login-button.git",
+      "channel_name": "doof-mit-open-login-button",
+      "project_type": "library",
+      "packaging_tool": "npm",
+      "versioning_strategy": "npm"
     }
   ]
 }


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/mit-open-login-button/issues/8

#### What's this PR do?
This PR adds the `mit-open-login-button` JS library to `repos_info.json`, allowing Doof to perform releases against it and publish it to NPM.

#### How should this be manually tested?
No manual testing locally required, needs to be deployed to be tested with Doof