### PR TITLE
Use mitopen-rc URL

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -37,7 +37,7 @@
       "name": "mit-open",
       "repo_url": "https://github.com/mitodl/mit-open.git",
       "ci_hash_url": "https://mit-open-ci.odl.mit.edu/static/hash.txt",
-      "rc_hash_url": "https://mit-open-rc.odl.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://mitopen-rc.odl.mit.edu/static/hash.txt",
       "prod_hash_url": "https://mitopen.odl.mit.edu/static/hash.txt",
       "channel_name": "product-mit-open-next",
       "project_type": "web_application",


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/release-script/issues/377

#### What's this PR do?
This PR updates doof to use https://mitopen-rc.odl.mit.edu/ for RC. the `mit-open-rc` URL sort of works but does not support keycloak login. 

#### How should this be manually tested?
Visit https://mitopen-rc.odl.mit.edu/. You should be able to log in via keycloak.
