### PR TITLE
Fix the detection of mit-open releases

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -36,9 +36,9 @@
     {
       "name": "mit-open",
       "repo_url": "https://github.com/mitodl/mit-open.git",
-      "ci_hash_url": "https://mit-open-ci.odl.mit.edu/static/hash.txt",
-      "rc_hash_url": "https://mitopen-rc.odl.mit.edu/static/hash.txt",
-      "prod_hash_url": "https://mitopen.odl.mit.edu/static/hash.txt",
+      "ci_hash_url": "https://api.mit-open-ci.odl.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://api.mitopen-rc.odl.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://api.mitopen.odl.mit.edu/static/hash.txt",
       "channel_name": "product-mit-open-next",
       "project_type": "web_application",
       "web_application_type": "django",


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
This fixes the bot not being able to detect releases because the API backend that has the current hash got moved and trying to serve it from the frontend raises issues with CDN caching. These could be fixed but are more time consuming than this small fix.

#### How should this be manually tested?
Can't test this locally.
