### PR TITLE
Rename learn repo to match the new name

### DIFF
--- a/bot_test.py
+++ b/bot_test.py
@@ -1030,7 +1030,7 @@ async def test_help(doof):
 @pytest.mark.parametrize("has_checkboxes", [True, False])
 async def test_wait_for_checkboxes(
     mocker, doof, sleep_sync_mock, test_repo, has_checkboxes, mock_labels
-):  # pylint: disable=unused-argument
+):  # pylint: disable=unused-argument,too-many-positional-arguments
     """wait_for_checkboxes should poll github, parse checkboxes and see if all are checked"""
     org, repo = get_org_and_repo(test_repo.repo_url)
     channel_id = test_repo.channel_id
@@ -1386,7 +1386,7 @@ async def test_start_new_releases(
     expected_version,
     has_release_pr,
     has_new_commits,
-):
+):  # pylint: disable=too-many-positional-arguments
     """start new releases command should iterate through releases and start ones without an existing PR"""
     old_version = "1.2.3"
     default_branch = "default"

--- a/repos_info.json
+++ b/repos_info.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "mit-learn",
-      "repo_url": "https://github.com/mitodl/mit-open.git",
+      "repo_url": "https://github.com/mitodl/mit-learn.git",
       "ci_hash_url": "https://api.ci.learn.mit.edu/static/hash.txt",
       "rc_hash_url": "https://api.rc.learn.mit.edu/static/hash.txt",
       "prod_hash_url": "https://api.learn.mit.edu/static/hash.txt",

--- a/status_test.py
+++ b/status_test.py
@@ -96,7 +96,7 @@ async def test_status_for_repo_last_pr(
     is_open,
     labels,
     expected,
-):  # pylint: disable=too-many-arguments
+):  # pylint: disable=too-many-arguments,too-many-positional-arguments
     """status_for_repo_last_pr should get the status for the most recent PR for a project"""
     release_pr = (
         ReleasePR("1.2.3", "http://example.com", "body", 12, is_open)
@@ -126,7 +126,7 @@ async def test_status_for_repo_last_pr(
 @pytest.mark.parametrize("has_commits", [True, False])
 @pytest.mark.parametrize("has_release_pr", [True, False])
 @pytest.mark.parametrize("is_open", [True, False])
-async def test_status_for_repo_new_commits(  # pylint: disable=too-many-arguments
+async def test_status_for_repo_new_commits(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     mocker, test_repo, test_repo_directory, has_commits, has_release_pr, is_open
 ):
     """status_for_repo_new_commits should check if there are new commits"""

--- a/version_test.py
+++ b/version_test.py
@@ -322,7 +322,7 @@ async def test_update_version_file(readonly):
             assert f.readline().strip() == old_version if readonly else new_version
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 @pytest.mark.parametrize("readonly", [True, False])
 @pytest.mark.parametrize(
     "versioning_strategy, expected_python, expected_js, expected_version_file",

--- a/web_test.py
+++ b/web_test.py
@@ -129,7 +129,7 @@ class FinishReleaseTests(AsyncHTTPTestCase):
         )
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 @pytest.mark.parametrize(
     "secret, timestamp, signature, body, expected",
     [


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
The repo was renamed, this updates the configuration to match it. Some lint changes too since those were failing

#### How should this be manually tested?
We'll test during deployments

