### PR TITLE
Install all the git

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,1 @@
-git
+git-all


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Doof is hitting the following error trying to run `git init -q` on an empty directory as part of it's release candidate generation process:

```
warning: templates not found in /usr/share/git-core/templates
```
I'm guessing this is because the `git` apt package doesn't actually include everything you need to run all git commands (how that passes muster idk), so I'm switching this to the `git-all` package instead which hopefully does, but we won't know until it deploys.

#### How should this be manually tested?
Test in heroku after merge.
