### PR TITLE
Add Unified Ecommerce to Doof

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -194,6 +194,17 @@
       "project_type": "library",
       "packaging_tool": "npm",
       "versioning_strategy": "npm"
+    },
+    {
+      "name": "unified-ecommerce",
+      "repo_url": "https://github.com/mitodl/unified-ecommerce.git",
+      "ci_hash_url": "https://api.pay-ci.ol.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://api.pay-ci.ol.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://api.pay.ol.mit.edu/static/hash.txt",
+      "channel_name": "product-unified-ecommerce",
+      "project_type": "web_application",
+      "web_application_type": "django",
+      "versioning_strategy": "python"
     }
   ]
 }

--- a/repos_info.json
+++ b/repos_info.json
@@ -198,10 +198,21 @@
     {
       "name": "unified-ecommerce",
       "repo_url": "https://github.com/mitodl/unified-ecommerce.git",
-      "ci_hash_url": "https://api.pay-ci.ol.mit.edu/static/hash.txt",
-      "rc_hash_url": "https://api.pay-ci.ol.mit.edu/static/hash.txt",
-      "prod_hash_url": "https://api.pay.ol.mit.edu/static/hash.txt",
-      "channel_name": "product-unified-ecommerce",
+      "ci_hash_url": "https://api-pay-ci.ol.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://api-pay-rc.ol.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://api-pay.ol.mit.edu/static/hash.txt",
+      "channel_name": "doof-ue-backend",
+      "project_type": "web_application",
+      "web_application_type": "django",
+      "versioning_strategy": "python"
+    },
+    {
+      "name": "unified-ecommerce-frontend",
+      "repo_url": "https://github.com/mitodl/unified-ecommerce-frontend.git",
+      "ci_hash_url": "https://pay-ci.ol.mit.edu/static/hash.txt",
+      "rc_hash_url": "https://pay-rc.ol.mit.edu/static/hash.txt",
+      "prod_hash_url": "https://pay.ol.mit.edu/static/hash.txt",
+      "channel_name": "doof-ue-frontend",
       "project_type": "web_application",
       "web_application_type": "django",
       "versioning_strategy": "python"


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/hq/issues/6236

#### What's this PR do?

Adds the Unified Ecommerce stuff in so Doof can coordinate releases for it. This is for both the frontend and the backend.

The frontend is coordinated through the `doof-ue-frontend` channel and the backend uses the `doof-ue-backend`. These are separate because they're two separate build processes and two separate codebases. These channels exist now but will need people to be added to them.

#### How should this be manually tested?

Not real sure. Maybe you could run it on the command line.

We'll likely need to adjust the build processes for both of these to write the GitHub hashes somewhere where doof can see them, but that's something to do in a different PR (or PRs). 