### PR TITLE
Small fix for UE Frontend, remove old project

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -215,7 +215,7 @@
       "channel_name": "doof-ue-frontend",
       "project_type": "web_application",
       "web_application_type": "django",
-      "versioning_strategy": "python"
+      "versioning_strategy": "npm"
     }
   ]
 }

--- a/repos_info.json
+++ b/repos_info.json
@@ -169,14 +169,6 @@
       "versioning_strategy": "npm"
     },
     {
-      "name": "edx-username-changer",
-      "repo_url": "https://github.com/mitodl/edx-username-changer.git",
-      "channel_name": "doof-edx-username-changer",
-      "project_type": "library",
-      "packaging_tool": "setuptools",
-      "versioning_strategy": "python"
-    },
-    {
       "name": "mitxonline",
       "repo_url": "https://github.com/mitodl/mitxonline.git",
       "ci_hash_url": "https://mitxonline-ci.mitxonline.mit.edu/static/hash.txt",


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?

The UE Frontend repo is a Node project - the version strategy needed to be set to `npm`. So, this fixes that.

This also removes the entry for `edx-username-changer` since that is now archived (or will be soon). This was tripping up the `status` command.

#### How should this be manually tested?

Follow the instructions to run the app on the command line. (You need a GitHub access token and the Slack token and secret, but you don't need actual secrets for the rest of the environment settings if you're just doing a basic test.) Then, you should be able to run `bot_local.py doof-ue-frontend status` and `bot_local.py doof-ue-frontend release notes` and get reasonable information back.

#### Any background context you want to provide?

There's a bunch of other projects that are in doof that should probably also be cleaned up, but this isn't the PR for that.
