### PR TITLE
Remove ocw-to-hugo repo

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -123,14 +123,6 @@
       "versioning_strategy": "python"
     },
     {
-      "name": "ocw-to-hugo",
-      "repo_url": "https://github.com/mitodl/ocw-to-hugo.git",
-      "channel_name": "doof-ocw-to-hugo",
-      "project_type": "library",
-      "packaging_tool": "npm",
-      "versioning_strategy": "npm"
-    },
-    {
       "name": "ocw-studio",
       "repo_url": "https://github.com/mitodl/ocw-studio.git",
       "channel_name": "doof-ocw-studio",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/7095.

### Description (What does it do?)
This PR removes the `ocw-to-hugo` integration from the release script.

### How can this be tested?
The `doof-ocw-to-hugo` channel will no longer function for releases, but this is fine since the ocw-to-hugo repository (https://github.com/mitodl/ocw-to-hugo) has already been archived.