### PR TITLE
Refactor for modern asyncio use and pin dependencies

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -130,7 +130,7 @@ class Bot:
         github_access_token,
         npm_token,
         timezone,
-        repos_info
+        repos_info,
     ):
         """
         Create the slack bot

--- a/bot.py
+++ b/bot.py
@@ -1645,6 +1645,7 @@ async def async_main():
 
     await bot.startup()
 
+
 def main():
     """main function for bot command"""
     tornado.ioloop.IOLoop.current().run_sync(async_main)

--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,7 @@ import re
 
 import pytz
 import sentry_sdk
+import tornado
 
 from client_wrapper import ClientWrapper
 from constants import (
@@ -1644,10 +1645,9 @@ async def async_main():
 
     await bot.startup()
 
-
 def main():
     """main function for bot command"""
-    asyncio.run(async_main())
+    tornado.ioloop.IOLoop.current().run_sync(async_main)
 
 
 if __name__ == "__main__":

--- a/bot.py
+++ b/bot.py
@@ -130,8 +130,7 @@ class Bot:
         github_access_token,
         npm_token,
         timezone,
-        repos_info,
-        loop,
+        repos_info
     ):
         """
         Create the slack bot
@@ -143,7 +142,6 @@ class Bot:
             npm_token (str): The NPM token to publish npm packages
             timezone (tzinfo): The time zone of the team interacting with the bot
             repos_info (list of RepoInfo): Information about the repositories connected to channels
-            loop (asyncio.events.AbstractEventLoop): The asyncio event loop
         """
         self.doof_id = doof_id
         self.slack_access_token = slack_access_token
@@ -151,7 +149,6 @@ class Bot:
         self.npm_token = npm_token
         self.timezone = timezone
         self.repos_info = repos_info
-        self.loop = loop
         # Keep track of long running or scheduled tasks
         self.tasks = set()
         self.doof_boot = now_in_utc()
@@ -1038,7 +1035,7 @@ class Bot:
                     title=f"Starting release {version} with these commits",
                     text=release_notes,
                 )
-                self.loop.create_task(
+                asyncio.create_task(
                     self._new_release(
                         repo_info=repo_info,
                         version=version,
@@ -1549,7 +1546,7 @@ class Bot:
             if not release_pr:
                 continue
 
-            self.loop.create_task(
+            asyncio.create_task(
                 self.run_release_lifecycle(
                     repo_info=repo_info, manager=None, release_pr=release_pr
                 )
@@ -1640,7 +1637,6 @@ async def async_main():
         npm_token=envs["NPM_TOKEN"],
         timezone=pytz.timezone(envs["TIMEZONE"]),
         repos_info=repos_info,
-        loop=asyncio.get_event_loop(),
         doof_id=doof_id,
     )
     app = make_app(secret=envs["SLACK_SECRET"], bot=bot)
@@ -1651,9 +1647,7 @@ async def async_main():
 
 def main():
     """main function for bot command"""
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main())
-    loop.run_forever()
+    asyncio.run(async_main())
 
 
 if __name__ == "__main__":

--- a/bot_local.py
+++ b/bot_local.py
@@ -48,7 +48,7 @@ async def async_main():
         github_access_token=envs["GITHUB_ACCESS_TOKEN"],
         timezone=envs["TIMEZONE"],
         npm_token=envs["NPM_TOKEN"],
-        repos_info=repos_info
+        repos_info=repos_info,
     )
 
     await bot.startup()

--- a/bot_local.py
+++ b/bot_local.py
@@ -48,8 +48,7 @@ async def async_main():
         github_access_token=envs["GITHUB_ACCESS_TOKEN"],
         timezone=envs["TIMEZONE"],
         npm_token=envs["NPM_TOKEN"],
-        repos_info=repos_info,
-        loop=asyncio.get_event_loop(),
+        repos_info=repos_info
     )
 
     await bot.startup()
@@ -63,8 +62,7 @@ async def async_main():
 
 def main():
     """Main function"""
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main())
+    asyncio.run(async_main())
 
 
 if __name__ == "__main__":

--- a/bot_test.py
+++ b/bot_test.py
@@ -58,7 +58,7 @@ class DoofSpoof(Bot):
             github_access_token=GITHUB_ACCESS,
             npm_token=NPM_TOKEN,
             timezone=pytz.timezone("America/New_York"),
-            repos_info=[WEB_TEST_REPO_INFO, LIBRARY_TEST_REPO_INFO]
+            repos_info=[WEB_TEST_REPO_INFO, LIBRARY_TEST_REPO_INFO],
         )
 
         self.slack_users = []

--- a/bot_test.py
+++ b/bot_test.py
@@ -50,7 +50,7 @@ NPM_TOKEN = "npm-token"
 class DoofSpoof(Bot):
     """Testing bot"""
 
-    def __init__(self, *, loop):
+    def __init__(self):
         """Since the testing bot isn't contacting slack or github we don't need these tokens here"""
         super().__init__(
             doof_id="Doofenshmirtz",
@@ -58,8 +58,7 @@ class DoofSpoof(Bot):
             github_access_token=GITHUB_ACCESS,
             npm_token=NPM_TOKEN,
             timezone=pytz.timezone("America/New_York"),
-            repos_info=[WEB_TEST_REPO_INFO, LIBRARY_TEST_REPO_INFO],
-            loop=loop,
+            repos_info=[WEB_TEST_REPO_INFO, LIBRARY_TEST_REPO_INFO]
         )
 
         self.slack_users = []
@@ -130,9 +129,9 @@ def sleep_sync_mock(mocker):
 
 
 @pytest.fixture
-def doof(event_loop, sleep_sync_mock):  # pylint: disable=unused-argument
+def doof(sleep_sync_mock):  # pylint: disable=unused-argument
     """Create a Doof"""
-    yield DoofSpoof(loop=event_loop)
+    yield DoofSpoof()
 
 
 @pytest.fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-python-dateutil
-pytz
-requests
-sentry-sdk
-tornado
-virtualenv
-packaging
+packaging==25.0
+python-dateutil==2.9.0.post0
+pytz==2025.2
+requests==2.32.5
+sentry-sdk==2.35.1
+tornado==6.5.2
+virtualenv==20.34.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,8 +1,8 @@
 black==25.1.0
-codecov
-pdbpp
-pylint
-pytest
-pytest-asyncio
-pytest-cov
-pytest-mock
+codecov==2.1.13
+pdbpp==0.11.7
+pylint==3.3.8
+pytest==8.4.1
+pytest-asyncio==1.1.0
+pytest-cov==6.2.1
+pytest-mock==3.14.1

--- a/web.py
+++ b/web.py
@@ -2,6 +2,7 @@
 Web server for handling slack webhooks
 """
 
+import asyncio
 import hmac
 import json
 
@@ -54,7 +55,7 @@ class ButtonHandler(RequestHandler):
         arguments = json.loads(
             self.get_argument("payload")
         )  # pylint: disable=no-value-for-parameter
-        self.bot.loop.create_task(self.bot.handle_webhook(webhook_dict=arguments))
+        asyncio.create_task(self.bot.handle_webhook(webhook_dict=arguments))
         await self.finish("")
 
 
@@ -87,7 +88,7 @@ class EventHandler(RequestHandler):
             await self.finish(challenge)
             return
 
-        self.bot.loop.create_task(self.bot.handle_event(webhook_dict=arguments))
+        asyncio.create_task(self.bot.handle_event(webhook_dict=arguments))
 
         await self.finish("")
 

--- a/web_test.py
+++ b/web_test.py
@@ -21,8 +21,7 @@ class FinishReleaseTests(AsyncHTTPTestCase):
 
     def setUp(self):
         self.secret = uuid.uuid4().hex
-        self.loop = asyncio.get_event_loop()
-        self.doof = DoofSpoof(loop=self.loop)
+        self.doof = DoofSpoof()
         self.app = make_app(secret=self.secret, bot=self.doof)
 
         super().setUp()

--- a/web_test.py
+++ b/web_test.py
@@ -1,6 +1,5 @@
 """Tests for the web server"""
 
-import asyncio
 import json
 from unittest.mock import patch
 import urllib.parse


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8196.

### Description (What does it do?)
This PR refactors the use of asyncio event loops to correspond to the modern practice of using `asyncio.run` instead of manually getting the current event loop, which is deprecated and was causing tests to fail. It also pins the requirements to the latest versions, so that the test environment for future PRs is predictable. Future version updates can be handled by `renovate[bot]`.

See https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop for related documentation on the changes to `asyncio`.

### How can this be tested?
All of the tests should now pass.