### PR TITLE
Fix H18 timeout by keeping event loop running after startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,6 @@ import re
 
 import pytz
 import sentry_sdk
-import tornado
 
 from client_wrapper import ClientWrapper
 from constants import (
@@ -1646,10 +1645,11 @@ async def async_main():
     await bot.startup()
 
 
-def main():
+async def main():
     """main function for bot command"""
-    tornado.ioloop.IOLoop.current().run_sync(async_main)
+    await async_main()
+    await asyncio.Event().wait()
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/release-script/pull/407.

### Description (What does it do?)
This PR fixes an issue with a `Server Request Interrupted` error when deployed to Heroku, caused by the event loop terminating after Doof startup.

### How can this be tested?
Test by deploying to Heroku and making sure there are no H18 errors.