### PR TITLE
Removed archived #doof-edx-sysadmin channel and edx-sysadmin config

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -75,14 +75,6 @@
       "versioning_strategy": "python"
     },
     {
-      "name": "edx-sysadmin",
-      "repo_url": "https://github.com/mitodl/edx-sysadmin.git",
-      "channel_name": "doof-edx-sysadmin",
-      "project_type": "library",
-      "packaging_tool": "setuptools",
-      "versioning_strategy": "python"
-    },
-    {
       "name": "rapid-response-xblock",
       "repo_url": "https://github.com/mitodl/rapid-response-xblock.git",
       "channel_name": "doof-edx-rapid-response-doof",


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

The channel doof-edx-sysadmin in Slack was removed, but Doof is still looking for it. So, this removes that repo and thus the dependency on the Slack channel.

### How can this be tested?

This is a config change so as long as it looks OK it should be OK. But you can probably test it locally if you want.
