### PR TITLE
Make sure there's a channel for Doof to talk to before adding it to the list of repos

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -344,7 +344,7 @@ def load_repos_info(channel_lookup):
             versioning_strategy=repo_info.get("versioning_strategy", FILE_VERSION),
         )
         for repo_info in repos_info["repos"]
-        if repo_info.get("repo_url")
+        if repo_info.get("repo_url") and repo_info.get("channel_name") and channel_lookup.get(repo_info.get("channel_name"))
     ]
 
     # some basic validation for sanity checking

--- a/lib_test.py
+++ b/lib_test.py
@@ -211,6 +211,21 @@ async def test_load_repos_info(mocker):
                     "packaging_tool": "none",
                     "versioning_strategy": FILE_VERSION,
                 },
+                {
+                    "name": "bad-no-channel",
+                    "repo_url": "https://github.com/mitodl/ocw-hugo-projects.git",
+                    "project_type": "library",
+                    "packaging_tool": "none",
+                    "versioning_strategy": FILE_VERSION,
+                },
+                {
+                    "name": "bad-nonexistant-channel",
+                    "repo_url": "https://github.com/mitodl/ocw-hugo-projects.git",
+                    "channel_name": "ghost-channel",
+                    "project_type": "library",
+                    "packaging_tool": "none",
+                    "versioning_strategy": FILE_VERSION,
+                },
             ]
         },
     )


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

#468 fixed the immediate issue that we had (`doof-edx-sysadmin` as a Slack channel went away) but doof should probably not just die because the channel gets culled. This adds a bit more checking to ensure that we're only loading repo info for repos that also have a Slack channel configured, and where the Slack channel exists.

### How can this be tested?

Can test this locally by configuring a repo:
- That doesn't have a channel listed in it
- That _has_ a channel listed, but not one that exists

It should skip over those repos.
