### PR TITLE
chore: drop course-search-utils from Doof

### DIFF
--- a/repos_info.json
+++ b/repos_info.json
@@ -137,14 +137,6 @@
       "versioning_strategy": "file"
     },
     {
-      "name": "course-search-utils",
-      "repo_url": "https://github.com/mitodl/course-search-utils.git",
-      "channel_name": "doof-course-search-utils",
-      "project_type": "library",
-      "packaging_tool": "npm",
-      "versioning_strategy": "npm"
-    },
-    {
       "name": "mitxonline",
       "repo_url": "https://github.com/mitodl/mitxonline.git",
       "ci_hash_url": "https://mitxonline-ci.mitxonline.mit.edu/static/hash.txt",


### PR DESCRIPTION
### What are the relevant tickets?

N/A — companion to https://github.com/mitodl/course-search-utils/pull/218

### Description (What does it do?)

Removes the `course-search-utils` entry from `repos_info.json`, so Doof no longer manages releases for that repository.

`course-search-utils` now releases itself using [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (GitHub Actions OIDC) driven by `semantic-release`, added in https://github.com/mitodl/course-search-utils/pull/218. It follows the pattern already used by [mitodl/smoot-design](https://github.com/mitodl/smoot-design), which has never been managed by Doof.

The motivation is that Doof authenticates to npm by writing an `.npmrc` containing an `NPM_TOKEN` ([`publish.py`](https://github.com/mitodl/release-script/blob/master/publish.py#L84-L98)), and that approach is now obsolete. It had also been failing in practice: npm's `latest` for `@mitodl/course-search-utils` is **3.5.2**, while the repo is tagged `v3.6.0` — two releases were tagged and written into `RELEASE.rst` but never actually reached the registry.

This is a configuration-only change; no Python code is touched.

After this merges, `mit-open-login-button` is the only remaining npm package in Doof:

```
$ jq -r '.repos[] | select(.packaging_tool == "npm") | .name' repos_info.json
mit-open-login-button
```

### How can this be tested?

The change is an 8-line deletion from a JSON config file. Verified locally that the remaining config still loads and passes the sanity checks in [`load_repos_info`](https://github.com/mitodl/release-script/blob/master/lib.py#L308):

- `repos_info.json` remains valid JSON, with 17 entries (down from 18).
- All 17 entries pass the loader's filter (`repo_url` and `channel_name` present and resolvable).
- All 17 pass the `packaging_tool` and `versioning_strategy` validation that `load_repos_info` raises on.
- No references to `course-search-utils` remain anywhere in the repo:

  ```
  $ grep -rn "course-search-utils\|course_search" --include="*.py" --include="*.json" --include="*.md" .
  (no matches)
  ```

To confirm behaviourally after merge, Doof should no longer list `course-search-utils` when asked for repo/release status, and the `doof-course-search-utils` Slack channel will no longer have a bot-managed release cycle.

### Additional Context

**Merge order does not matter.** Doof only acts on a repository when a release is explicitly requested through it, so there is no window in which both systems would try to publish concurrently. That said, merging https://github.com/mitodl/course-search-utils/pull/218 first is the tidier sequence, since it means the replacement is in place before the old path is removed.

**The `doof-course-search-utils` Slack channel is left alone.** Removing the entry stops Doof from managing the repo but does not archive or modify the channel; that can be handled separately if the team wants it cleaned up.
