### PR TITLE
docs: add AGENTS.md, switch README to uv, drop dead Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# AGENTS.md
+
+Doof (Heinz Doofenshmirtz) is MIT Open Learning's Slack release bot. It listens for
+`@doof <command>` in Slack, maps each channel to a project via `repos_info.json`, and
+drives the ODL release lifecycle: release notes -> `release-candidate` branch with a
+version bump -> "Release X.Y.Z" PR with per-author checkboxes -> wait for RC deploy ->
+wait for checkbox sign-off -> merge to `release`, tag, verify prod. Library projects
+also publish to PyPI (twine) or npm.
+
+`README.md` is accurate and current - read it for the human-facing side this file
+does not cover: the full Doof command list, the release lifecycle in prose, and the
+Heroku deployment. This file covers what you need to *change* the code.
+
+## Setup and commands
+
+Python 3.13, managed with **uv**. `npm install` is required, not optional - the
+`git-release-notes` binary is invoked from `node_modules/.bin/`.
+
+```bash
+npm install            # JS deps (git-release-notes)
+uv sync                # Python deps, including the dev group
+uv run ruff check      # lint
+uv run pytest .        # full suite; coverage is auto-applied via pytest.ini
+
+uv run ruff format                           # format (not gated by CI)
+uv run pytest bot_test.py::test_release -x   # single test
+uv run python3 bot_local.py micromasters-eng release 4.5.6   # drive Doof from a shell
+```
+
+Never use `pip`, `poetry`, or a hand-rolled venv - always `uv`. Run everything through
+`uv run` so it uses the project environment.
+
+There is no typechecker and no pre-commit config. `pyproject.toml` has no `[tool.*]`
+sections, so ruff runs on defaults.
+
+CI (`.github/workflows/ci.yml`, `on: push`) runs exactly the first four commands -
+`npm install`, `uv sync`, `uv run ruff check`, `uv run pytest .` - and nothing else.
+A second workflow runs **zizmor** over `.github/workflows/**` - any new workflow step
+must be SHA-pinned with least-privilege `permissions:` or it fails.
+
+Two local gotchas:
+
+- **`node` must be on your PATH**, not just installed under `node_modules/`. If your
+  environment provides only python and uv (a nix devshell, a slim container), ~10 tests
+  in `release_test.py` / `finish_release_test.py` / `version_test.py` fail with
+  `FileNotFoundError: 'node'`. CI's `ubuntu-24.04` runner has node preinstalled, so
+  this is a local-only gap - check for it before blaming your change.
+- `lib.py` is not `ruff format`-clean. CI only gates `ruff check`, so a blind
+  `uv run ruff format` adds an unrelated `lib.py` diff. Format only the files you
+  touched.
+
+## Layout
+
+Flat modules at the repo root - no package directory, no `src/`. Each module has a
+sibling `<module>_test.py`.
+
+| File | Responsibility |
+|---|---|
+| `bot.py` | `Bot`: Slack I/O, command table, release lifecycle state machine, `get_envs()`, `main()` |
+| `bot_local.py` | `ConsoleBot` - run one command from a shell instead of Slack |
+| `web.py` | Tornado app: button/event handlers, HMAC `is_authenticated()` |
+| `release.py` | Cut the release: notes, version bump, `generate_release_pr` |
+| `finish_release.py` | Merge `release-candidate` -> `release`, tag, set release date |
+| `publish.py` | `upload_to_pypi` (twine in a virtualenv), `upload_to_npm` |
+| `version.py` | Read/write versions per versioning strategy |
+| `github.py` | GitHub REST + GraphQL (`run_query`), PRs, labels |
+| `slack.py` | Cursor pagination, channel info, Doof's user ID |
+| `lib.py` | Shared helpers: `parse_checkmarks`, `get_release_pr`, `init_working_dir`, `load_repos_info` |
+| `status.py` | Per-repo release status/emoji for `status` |
+| `wait_for_deploy.py` | Poll a `hash.txt` URL until the deployed hash matches |
+| `async_subprocess.py` | asyncio `check_call`/`check_output`/`call` - `cwd` is required |
+| `client_wrapper.py` | `requests.Session` with retries, wrapped in async methods |
+| `constants.py` | Project/versioning/deploy types, GitHub label names, tool paths |
+| `exception.py` | `InputException`, `ReleaseException`, and friends |
+| `repo_info.py` | The `RepoInfo` namedtuple |
+| `repos_info.json` | Config: repo -> channel, URLs, project type, versioning strategy |
+
+## Conventions
+
+- **Async everywhere.** Subprocesses go through `async_subprocess`, which requires an
+  explicit `cwd=` because `os.chdir` is not per-coroutine safe. Never call
+  `subprocess` or `os.chdir` directly in a coroutine.
+- **Never touch the working tree.** All repo work happens in a temp clone via the
+  `init_working_dir` async context manager in `lib.py`.
+- **Keyword-only args** are the norm:
+  `async def finish_release(*, github_access_token, repo_info, version, timezone)`.
+  Google-style docstrings (`Args:` / `Returns:`) on essentially every function.
+- **`namedtuple`, not dataclasses**, for structs (`RepoInfo`, `Command`, `Parser`,
+  `ReleasePR`).
+- **Release state lives in GitHub PR labels**, not a database: `deploying to rc`,
+  `waiting for checkboxes`, `all checkboxes checked`, `deploying to prod`,
+  `deployed to prod` (see `RELEASE_LABELS`). Progress is also read from the release
+  PR body's checkboxes via `lib.parse_checkmarks`.
+- Bare `except:  # noqa: E722` in `bot.py`'s top-level handlers is **deliberate** -
+  it keeps the bot alive. Errors surface to Slack as Doofenshmirtz-flavored quips;
+  `InputException` / `ReleaseException` are the expected errors reported verbatim.
+- Target repos' default branch is resolved at runtime by `lib.get_default_branch`
+  (`main` and legacy `master` both supported). Do not hardcode it.
+
+## Testing
+
+- Test files are **`<module>_test.py`**, colocated at the repo root - *not* `test_*.py`.
+- `pytest-asyncio` is in **strict mode**, so every async test module needs a
+  module-level `pytestmark = pytest.mark.asyncio` or its tests silently do not run.
+- Use **`mocker.async_patch(target, **kwargs)`**, the custom `pytest-mock` extension
+  defined in `conftest.py`, instead of `AsyncMock`. It returns the underlying `Mock`
+  so you can assert calls:
+  `mocker.async_patch("bot.get_release_pr", return_value=None)`.
+- An autouse `log_exception` fixture makes `bot.log.exception` / `bot.log.error` raise,
+  so a swallowed exception fails the test loudly. Expect that if you add broad excepts.
+- Repo fixtures in `conftest.py`: `test_repo`, `library_test_repo`,
+  `npm_library_test_repo`, `timezone`. They build **real git repos** by
+  `git fast-import`-ing `test-repo.gz` (see `test_util.make_test_repo`).
+- No `responses` / `vcr` / `betamax`. Mock GitHub with
+  `mocker.async_patch("github.run_query", return_value=<payload>)` using the canned
+  JSON payloads; fake Slack with the `DoofSpoof(Bot)` subclass in `bot_test.py`, which
+  records messages and exposes `doof.said(...)` for assertions.
+- Use the `sleep_sync_mock` fixture (`bot_test.py`) so lifecycle tests do not
+  actually wait.
+- `@pytest.mark.parametrize` is used heavily - follow suit over copy-pasted cases.
+
+## Environment
+
+`bot.get_envs()` hard-fails at startup unless all of these are set:
+`SLACK_ACCESS_TOKEN`, `BOT_ACCESS_TOKEN`, `GITHUB_ACCESS_TOKEN`, `NPM_TOKEN`,
+`SLACK_SECRET`, `TIMEZONE`, `PORT`, `PYPI_USERNAME`, `PYPI_PASSWORD`,
+`PYPITEST_USERNAME`, `PYPITEST_PASSWORD`. Optional: `SENTRY_SDK` (the Sentry *DSN*,
+despite the name).
+
+`BOT_ACCESS_TOKEN` and the `PYPITEST_*` pair are required but currently unused - a
+known wart. `bot_local.py` enforces the same list, so fill in fakes for whatever your
+command does not need.
+
+Runtime deps are **exact-pinned** (`==`) in `pyproject.toml`; only `ruff` floats.
+Keep it that way - Renovate manages the bumps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-test: shunit2
-	./test.sh
-
-shunit2:
-	git clone https://github.com/kward/shunit2.git
-

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Web application projects:
 ### Command line release process
 If Slack is down you may need to run releases from a shell using `bot_local.py`. To do that:
 
- - Create a virtualenv for this project and install dependencies from `requirements.txt`.
+ - Install dependencies with `uv sync` (see [Dependencies](#dependencies) below).
  - Set environment variables listed above. Until we make environment variable checks more fine
 grained it is probably easiest to fill in fake values for the values you don't need.
- - Start a release: `python3 bot_local.py micromasters-eng release 4.5.6` for example.
- - Merge the release: `python3 bot_local.py micromasters-eng finish release`.
+ - Start a release: `uv run python3 bot_local.py micromasters-eng release 4.5.6` for example.
+ - Merge the release: `uv run python3 bot_local.py micromasters-eng finish release`.
  
 Note that Doof and `bot_local.py` use temporary directories for all releases so none of your
 work in progress will be affected or will affect the release.
@@ -100,21 +100,25 @@ Git is available as a precompiled binary as well as from Homebrew on OSX:
 
     brew install git
 
-#### [Python 3.7+ - https://www.python.org/downloads/](https://www.python.org/downloads/)
+#### [Python 3.13 - https://www.python.org/downloads/](https://www.python.org/downloads/)
 
-Python 3.7+ is required.
+Python 3.13 is required (see `.python-version`). `uv` can install it for you.
 
 #### Python libraries
 
-All python dependencies are listed in `requirements.txt`. (For testing also install `test_requirements.txt`.)
+Python dependencies are managed with [uv](https://docs.astral.sh/uv/) and declared in
+`pyproject.toml`, with exact versions locked in `uv.lock`. Install
+[uv](https://docs.astral.sh/uv/getting-started/installation/), then:
 
-Create a virtualenv and install the Python dependencies. For example:
+    uv sync
 
-  - `virtualenv /tmp/release_venv -p /usr/bin/python3`
-  - `. /tmp/release_venv/bin/activate`
-  - `pip install -r requirements.txt -r test_requirements.txt`
+That creates the virtualenv and installs both the runtime dependencies and the `dev`
+dependency group (pytest and friends). Run project scripts through `uv run` so they use
+that environment, for example:
 
-Make sure to also run the various scripts from within the virtualenv.
+    uv run pytest .
+    uv run ruff check
+    uv run python3 bot_local.py micromasters-eng release 4.5.6
 
 #### Javascript libraries
 Make sure you have `npm` installed, then install any dependencies:


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Adds `AGENTS.md` documenting setup, layout, conventions, and testing idioms for this repo, with `CLAUDE.md` as a symlink to it so Claude Code picks it up without a second copy to drift.
- Switches the README's setup instructions from pip/virtualenv to `uv`. The old instructions told you to `pip install -r requirements.txt -r test_requirements.txt`; neither file exists in the repo, so they could not have worked.
- Corrects the README's Python requirement from 3.7+ to 3.13, matching `.python-version` and `requires-python = ">=3.13"`.
- Deletes the `Makefile`. Its only substantive target ran `./test.sh`, which is not in the repo, so `make test` always failed. Nothing in CI, `Procfile`, or `app.json` invokes `make`.

<details>
<summary><b>Implementation details</b></summary>
<br>

`AGENTS.md` is deliberately scoped to what you need in order to *change* the code, and points at the README for the human-facing material it does not duplicate (Doof's command list, the release lifecycle in prose, Heroku deployment).

The testing section captures the conventions that are easy to get wrong here:

- Test files are `<module>_test.py`, not `test_*.py`.
- `pytest-asyncio` runs in strict mode with no `asyncio_mode` set anywhere, so each async test module needs a module-level `pytestmark = pytest.mark.asyncio`. All 13 currently do; a new file that omits it will have its tests silently collected-but-not-run.
- `conftest.py` overrides the `pytest-mock` `mocker` fixture to add `mocker.async_patch`, which is used in place of `AsyncMock` throughout.
- An autouse `log_exception` fixture makes `bot.log.exception`/`bot.log.error` raise, so exceptions swallowed by `bot.py`'s deliberate bare excepts still fail tests.

The setup section separates the four commands CI actually runs (`npm install`, `uv sync`, `uv run ruff check`, `uv run pytest .`) from the optional ones, because `ruff format` is *not* gated by CI and `lib.py` is currently not format-clean — running it repo-wide produces an unrelated diff. That is called out in the doc.

Two gotchas are documented rather than fixed here, since both are environmental:

- `node` must be on `PATH`, not merely installed under `node_modules/`. `constants.py` invokes the `git-release-notes` and `yarn` binaries via `node`, so an environment with only python and uv fails ~10 tests in `release_test.py`, `finish_release_test.py`, and `version_test.py` with `FileNotFoundError: 'node'`. CI's `ubuntu-24.04` image has node preinstalled.
- `lib.py`'s formatting, as above.

</details>

### How can this be tested?
This is a docs change plus the removal of a file that could not execute, so the check is that the documented commands are real and that CI stays green.

Commands from the new docs, run on this branch:

- `uv sync` — succeeds
- `uv run ruff check` — `All checks passed!`
- `uv run pytest bot_test.py::test_release -x` — 2 passed
- `uv run pytest .` — 235 passed, 10 failed

The 10 failures are pre-existing and environmental, not caused by this branch: my shell has no `node` on `PATH`, and every failure is a `FileNotFoundError: 'node'` (or a downstream `AsyncCalledProcessError`) from the `git-release-notes`/`yarn` invocations in `constants.py`. They reproduce on `master`. CI has node, so the honest verification for that number is the CI run on this PR rather than my local result — please confirm it comes back green.

To check the two doc claims most likely to mislead someone if wrong:

```
grep -l "pytestmark = pytest.mark.asyncio" *_test.py   # expect all 13 test modules
grep -n "async_patch" conftest.py                      # expect the custom fixture
```

### Additional Context
- `CLAUDE.md` is committed as a symlink (mode `120000`) rather than a duplicate file. If anyone's tooling or platform does not follow it, say so and I'll swap it for a stub that points at `AGENTS.md`.
- I left `README.md`'s Doof usage, release-process, and deployment sections untouched; only the dependency/setup material and the Python version changed.
- `Procfile` still runs `web: python3 bot.py` via the Heroku buildpacks rather than uv. Changing the deploy path felt out of scope for a docs PR, but it's worth a follow-up if we want one dependency story everywhere.
