### PR TITLE
refactor: drop release-date stamping, tag web apps at release-candidate time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@ Doof (Heinz Doofenshmirtz) is MIT Open Learning's Slack release bot. It listens 
 `@doof <command>` in Slack, maps each channel to a project via `repos_info.json`, and
 drives the ODL release lifecycle: release notes -> `release-candidate` branch with a
 version bump -> "Release X.Y.Z" PR with per-author checkboxes -> wait for RC deploy ->
-wait for checkbox sign-off -> merge to `release`, tag, verify prod. Library projects
-also publish to PyPI (twine) or npm.
+wait for checkbox sign-off -> merge to `release`, verify prod. Web applications are
+tagged when the release candidate is cut; libraries are tagged when the release is
+finished, then published to PyPI (twine) or npm.
 
 `README.md` is accurate and current - read it for the human-facing side this file
 does not cover: the full Doof command list, the release lifecycle in prose, and the
@@ -60,7 +61,7 @@ sibling `<module>_test.py`.
 | `bot_local.py` | `ConsoleBot` - run one command from a shell instead of Slack |
 | `web.py` | Tornado app: button/event handlers, HMAC `is_authenticated()` |
 | `release.py` | Cut the release: notes, version bump, `generate_release_pr` |
-| `finish_release.py` | Merge `release-candidate` -> `release`, tag, set release date |
+| `finish_release.py` | Merge `release-candidate` -> `release`, tag |
 | `publish.py` | `upload_to_pypi` (twine in a virtualenv), `upload_to_npm` |
 | `version.py` | Read/write versions per versioning strategy |
 | `github.py` | GitHub REST + GraphQL (`run_query`), PRs, labels |
@@ -83,7 +84,7 @@ sibling `<module>_test.py`.
 - **Never touch the working tree.** All repo work happens in a temp clone via the
   `init_working_dir` async context manager in `lib.py`.
 - **Keyword-only args** are the norm:
-  `async def finish_release(*, github_access_token, repo_info, version, timezone)`.
+  `async def finish_release(*, github_access_token, repo_info, version)`.
   Google-style docstrings (`Args:` / `Returns:`) on essentially every function.
 - **`namedtuple`, not dataclasses**, for structs (`RepoInfo`, `Command`, `Parser`,
   `ReleasePR`).
@@ -109,7 +110,7 @@ sibling `<module>_test.py`.
 - An autouse `log_exception` fixture makes `bot.log.exception` / `bot.log.error` raise,
   so a swallowed exception fails the test loudly. Expect that if you add broad excepts.
 - Repo fixtures in `conftest.py`: `test_repo`, `library_test_repo`,
-  `npm_library_test_repo`, `timezone`. They build **real git repos** by
+  `npm_library_test_repo`. They build **real git repos** by
   `git fast-import`-ing `test-repo.gz` (see `test_util.make_test_repo`).
 - No `responses` / `vcr` / `betamax`. Mock GitHub with
   `mocker.async_patch("github.run_query", return_value=<payload>)` using the canned
@@ -123,7 +124,7 @@ sibling `<module>_test.py`.
 
 `bot.get_envs()` hard-fails at startup unless all of these are set:
 `SLACK_ACCESS_TOKEN`, `BOT_ACCESS_TOKEN`, `GITHUB_ACCESS_TOKEN`, `NPM_TOKEN`,
-`SLACK_SECRET`, `TIMEZONE`, `PORT`, `PYPI_USERNAME`, `PYPI_PASSWORD`,
+`SLACK_SECRET`, `PORT`, `PYPI_USERNAME`, `PYPI_PASSWORD`,
 `PYPITEST_USERNAME`, `PYPITEST_PASSWORD`. Optional: `SENTRY_SDK` (the Sentry *DSN*,
 despite the name).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ be all set.
   - `GITHUB_ACCESS_TOKEN` - Used to access information about github repos and to create new pull requests.
   - `NPM_TOKEN` - Used to publish NPM packages
   - `SLACK_SECRET` - Used to authenticate requests from Slack to Doof (ie the finish release button, events API.)
-  - `TIMEZONE` - The timezone of the team working with Doof
   - `PORT` - The port of the webserver, used for receiving webhooks from Slack
   - `PYPITEST_USERNAME` - The PyPI username to upload testing Python packages
   - `PYPITEST_PASSWORD` - The PyPI password to upload testing Python packages

--- a/app.json
+++ b/app.json
@@ -26,9 +26,6 @@
     "PORT": {
       "description": "Heroku port number to use for web server"
     },
-    "TIMEZONE": {
-      "description": "The time zone of the team"
-    },
     "SLACK_SECRET": {
       "description": "The secret to authenticate Slack requests to our APIs"
     }

--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,6 @@ import logging
 import json
 import re
 
-import pytz
 import sentry_sdk
 
 from client_wrapper import ClientWrapper
@@ -103,7 +102,6 @@ def get_envs():
         "GITHUB_ACCESS_TOKEN",
         "NPM_TOKEN",
         "SLACK_SECRET",
-        "TIMEZONE",
         "PORT",
         "PYPI_USERNAME",
         "PYPI_PASSWORD",
@@ -129,7 +127,6 @@ class Bot:
         slack_access_token,
         github_access_token,
         npm_token,
-        timezone,
         repos_info,
     ):
         """
@@ -140,14 +137,12 @@ class Bot:
             slack_access_token (str): The OAuth access token used to interact with Slack
             github_access_token (str): The Github access token used to interact with Github
             npm_token (str): The NPM token to publish npm packages
-            timezone (tzinfo): The time zone of the team interacting with the bot
             repos_info (list of RepoInfo): Information about the repositories connected to channels
         """
         self.doof_id = doof_id
         self.slack_access_token = slack_access_token
         self.github_access_token = github_access_token
         self.npm_token = npm_token
-        self.timezone = timezone
         self.repos_info = repos_info
         # Keep track of long running or scheduled tasks
         self.tasks = set()
@@ -829,7 +824,6 @@ class Bot:
             github_access_token=self.github_access_token,
             repo_info=repo_info,
             version=version,
-            timezone=self.timezone,
         )
 
         if repo_info.project_type == WEB_APPLICATION_TYPE:
@@ -1634,7 +1628,6 @@ async def async_main():
         slack_access_token=envs["SLACK_ACCESS_TOKEN"],
         github_access_token=envs["GITHUB_ACCESS_TOKEN"],
         npm_token=envs["NPM_TOKEN"],
-        timezone=pytz.timezone(envs["TIMEZONE"]),
         repos_info=repos_info,
         doof_id=doof_id,
     )

--- a/bot_local.py
+++ b/bot_local.py
@@ -45,7 +45,6 @@ async def async_main():
         doof_id="console",
         slack_access_token=envs["SLACK_ACCESS_TOKEN"],
         github_access_token=envs["GITHUB_ACCESS_TOKEN"],
-        timezone=envs["TIMEZONE"],
         npm_token=envs["NPM_TOKEN"],
         repos_info=repos_info,
     )

--- a/bot_local_test.py
+++ b/bot_local_test.py
@@ -14,7 +14,6 @@ async def test_bot_local(mocker, test_repo):
     """
     channel_name = "doof_channel"
     channel_id = "D1234567"
-    timezone = "America/New_York"
     slack_token = "slack token"
     github_token = "github_token"
     npm_token = "npm_token"
@@ -27,7 +26,6 @@ async def test_bot_local(mocker, test_repo):
             "SLACK_ACCESS_TOKEN": slack_token,
             "GITHUB_ACCESS_TOKEN": github_token,
             "NPM_TOKEN": npm_token,
-            "TIMEZONE": timezone,
         },
     )
     get_channels_info = mocker.async_patch(

--- a/bot_test.py
+++ b/bot_test.py
@@ -4,7 +4,6 @@ import asyncio
 from datetime import timedelta
 
 import pytest
-import pytz
 
 from bot import (
     CommandArgs,
@@ -56,7 +55,6 @@ class DoofSpoof(Bot):
             slack_access_token=SLACK_ACCESS,
             github_access_token=GITHUB_ACCESS,
             npm_token=NPM_TOKEN,
-            timezone=pytz.timezone("America/New_York"),
             repos_info=[WEB_TEST_REPO_INFO, LIBRARY_TEST_REPO_INFO],
         )
 
@@ -675,7 +673,6 @@ async def test_finish_release(doof, mocker, project_type, mock_labels):
         github_access_token=GITHUB_ACCESS,
         repo_info=test_repo,
         version=version,
-        timezone=doof.timezone,
     )
     assert doof.said(f"Merged evil scheme {version} for {test_repo.name}!")
     if project_type == WEB_APPLICATION_TYPE:
@@ -776,7 +773,6 @@ async def test_webhook_finish_release(
         github_access_token=doof.github_access_token,
         repo_info=test_repo,
         version=pr_body.version,
-        timezone=doof.timezone,
     )
     assert doof.said("Merging...")
     assert not doof.said("Error")

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@
 import os
 
 import pytest
-import pytz
 
 from constants import (
     DJANGO,
@@ -120,12 +119,6 @@ def library_test_repo(library_test_repo_directory):
 def npm_library_test_repo(library_test_repo):
     """Create a repository"""
     yield NPM_TEST_REPO_INFO
-
-
-@pytest.fixture
-def timezone():
-    """Return a timezone object"""
-    yield pytz.timezone("America/New_York")
 
 
 @pytest.fixture

--- a/finish_release.py
+++ b/finish_release.py
@@ -1,15 +1,12 @@
 """Release script to finish the release"""
 
-import os
-import re
-from datetime import datetime
-
 from async_subprocess import (
+    call,
     check_call,
     check_output,
 )
-from exception import VersionMismatchException
-from lib import get_default_branch
+from exception import ReleaseException, VersionMismatchException
+from lib import get_commit_hash, get_default_branch, tag_exists
 from release import (
     init_working_dir,
     validate_dependencies,
@@ -34,68 +31,60 @@ async def check_release_tag(version, *, root):
         )
 
 
-async def tag_release(version, *, root):
-    """Add git tag for release"""
-    await check_call(
-        ["git", "tag", "-a", "-m", f"Release {version}", f"v{version}"],
-        cwd=root,
-    )
-    await check_call(["git", "push", "--follow-tags"], cwd=root)
+async def verify_release_tag(version, *, root):
+    """
+    Check that an existing release tag actually identifies the release being finished
 
+    Tags are immutable, so a tag pointing at unrelated code cannot be corrected here.
+    Fail rather than finish a release whose version tag identifies the wrong commit.
 
-async def set_release_date(version, timezone, *, root):
-    """Sets the release date(s) in RELEASE.rst for any versions missing it"""
-    release_filename = os.path.join(root, "RELEASE.rst")
-    if not os.path.isfile(release_filename):
+    Args:
+        version (str): The version of the release
+        root (str): The path to the repository
+    """
+    tag = f"v{version}"
+    tag_commit = await get_commit_hash(tag, root=root)
+    rc_commit = await get_commit_hash("release-candidate", root=root)
+    if tag_commit == rc_commit:
         return
-    date_format = "%B %d, %Y"
-    await check_call(["git", "fetch", "--tags"], cwd=root)
-    await check_call(["git", "checkout", "release-candidate"], cwd=root)
 
-    with open(release_filename, "r", encoding="utf-8") as f:
-        existing_note_lines = f.readlines()
-
-    with open(release_filename, "w", encoding="utf-8") as f:
-        for line in existing_note_lines:
-            if line.startswith("Version ") and "Released" not in line:
-                version_match = re.search(r"[0-9\.]+", line)
-                if version_match:
-                    version_line = version_match.group(0)
-                    if version_line == version:
-                        localtime = datetime.now().strftime(date_format)
-                    else:
-                        version_output = await check_output(
-                            [
-                                "git",
-                                "log",
-                                "-1",
-                                "--format=%ai",
-                                f"v{version_line}",
-                            ],
-                            cwd=root,
-                        )
-                        version_date = version_output.rstrip()
-                        localtime = (
-                            datetime.strptime(
-                                version_date.decode("utf-8"), "%Y-%m-%d %H:%M:%S %z"
-                            )
-                            .astimezone(timezone)
-                            .strftime(date_format)
-                        )
-                    line = f"Version {version_line} (Released {localtime})\n"
-            f.write(line)
-
-    await check_call(
-        [
-            "git",
-            "commit",
-            "-q",
-            release_filename,
-            "-m",
-            f"Release date for {version}",
-        ],
-        cwd=root,
+    # A tag created while finishing the release lands on the release merge commit
+    # instead, so accept any tag that contains the release
+    contains_release = (
+        await call(
+            ["git", "merge-base", "--is-ancestor", rc_commit, tag_commit], cwd=root
+        )
+        == 0
     )
+    if not contains_release:
+        raise ReleaseException(
+            f"Tag {tag} points at {tag_commit}, which does not contain the "
+            f"release-candidate commit {rc_commit}. Tags are immutable, so this "
+            f"release cannot be finished under this version number."
+        )
+
+
+async def tag_release(version, *, root):
+    """
+    Add git tag for release, unless the release candidate was already tagged when it
+    was cut
+
+    Web application projects are tagged when the release candidate is cut, so the tag is
+    normally already here and is verified rather than recreated. Library projects, and
+    release candidates cut before tagging moved earlier, have no tag yet.
+
+    Args:
+        version (str): The version of the release
+        root (str): The path to the repository
+    """
+    if await tag_exists(version, root=root):
+        await verify_release_tag(version, root=root)
+    else:
+        await check_call(
+            ["git", "tag", "-a", "-m", f"Release {version}", f"v{version}"],
+            cwd=root,
+        )
+    await check_call(["git", "push", "--follow-tags"], cwd=root)
 
 
 async def merge_release(*, root):
@@ -108,7 +97,7 @@ async def merge_release(*, root):
     await check_call(["git", "push"], cwd=root)
 
 
-async def finish_release(*, github_access_token, repo_info, version, timezone):
+async def finish_release(*, github_access_token, repo_info, version):
     """
     Merge release to master and deploy to production
 
@@ -116,13 +105,11 @@ async def finish_release(*, github_access_token, repo_info, version, timezone):
         github_access_token (str): Github access token
         repo_info (RepoInfo): The info of the project being released
         version (str): The new version of the release
-        timezone (any): Some timezone object to set the proper release datetime string
     """
 
     await validate_dependencies()
     async with init_working_dir(github_access_token, repo_info.repo_url) as working_dir:
         await check_release_tag(version, root=working_dir)
-        await set_release_date(version, timezone, root=working_dir)
         await merge_release_candidate(root=working_dir)
         await tag_release(version, root=working_dir)
         await merge_release(root=working_dir)

--- a/finish_release_test.py
+++ b/finish_release_test.py
@@ -1,14 +1,9 @@
 """Tests for finish_release.py"""
 
-from datetime import datetime
-import re
-import os
-
 import pytest
 
-from exception import VersionMismatchException
-from lib import check_call
-from release import create_release_notes
+from exception import ReleaseException, VersionMismatchException
+from lib import check_call, get_commit_hash
 from release_test import make_empty_commit
 from finish_release import (
     check_release_tag,
@@ -16,7 +11,7 @@ from finish_release import (
     merge_release,
     merge_release_candidate,
     tag_release,
-    set_release_date,
+    verify_release_tag,
 )
 from test_util import async_context_manager_yielder
 
@@ -73,21 +68,99 @@ async def test_merge_release(mocker):
     default_branch_mock.assert_called_once_with(root)
 
 
-async def test_tag_release(mocker, test_repo_directory):
-    """tag_release should tag the release"""
-    version = "version"
+@pytest.mark.parametrize("already_tagged", [True, False])
+async def test_tag_release(mocker, test_repo_directory, already_tagged):
+    """
+    tag_release should tag the release, unless the release candidate was already tagged
+    when it was cut, and should push either way
+    """
+    version = "1.2.3"
+    await check_call(
+        ["git", "checkout", "-q", "-b", "release-candidate"], cwd=test_repo_directory
+    )
+    make_empty_commit("initial", f"Release {version}", cwd=test_repo_directory)
+    if already_tagged:
+        await check_call(
+            ["git", "tag", "-a", "-m", f"Release {version}", f"v{version}"],
+            cwd=test_repo_directory,
+        )
     patched_check_call = mocker.async_patch("finish_release.check_call")
+
     await tag_release(version, root=test_repo_directory)
-    patched_check_call.assert_any_call(
+
+    tag_call = mocker.call(
         ["git", "tag", "-a", "-m", f"Release {version}", f"v{version}"],
         cwd=test_repo_directory,
     )
+    assert (tag_call in patched_check_call.mock_calls) is not already_tagged
     patched_check_call.assert_any_call(
         ["git", "push", "--follow-tags"], cwd=test_repo_directory
     )
 
 
-async def test_finish_release(mocker, timezone, test_repo_directory, test_repo):
+async def test_tag_release_wrong_commit(mocker, test_repo_directory):
+    """
+    tag_release should refuse to finish a release when the existing tag identifies
+    unrelated code, since the tag cannot be moved
+    """
+    version = "1.2.3"
+    await check_call(
+        ["git", "checkout", "-q", "-b", "release-candidate"], cwd=test_repo_directory
+    )
+    make_empty_commit("initial", f"Release {version}", cwd=test_repo_directory)
+    rc_commit = await get_commit_hash("HEAD", root=test_repo_directory)
+
+    # tag a commit on a divergent branch, so it is neither the release commit nor a
+    # descendant of it
+    await check_call(
+        ["git", "checkout", "-q", "-b", "unrelated", "HEAD~1"], cwd=test_repo_directory
+    )
+    make_empty_commit("someone", "unrelated work", cwd=test_repo_directory)
+    unrelated_commit = await get_commit_hash("HEAD", root=test_repo_directory)
+    await check_call(
+        ["git", "tag", "-a", "-m", f"Release {version}", f"v{version}"],
+        cwd=test_repo_directory,
+    )
+    patched_check_call = mocker.async_patch("finish_release.check_call")
+
+    with pytest.raises(ReleaseException) as exception:
+        await tag_release(version, root=test_repo_directory)
+
+    assert exception.value.args[0] == (
+        f"Tag v{version} points at {unrelated_commit}, which does not contain the "
+        f"release-candidate commit {rc_commit}. Tags are immutable, so this release "
+        f"cannot be finished under this version number."
+    )
+    patched_check_call.assert_not_called()
+
+
+async def test_verify_release_tag_allows_descendant(test_repo_directory):
+    """
+    verify_release_tag should accept a tag on a commit that contains the release, which
+    is where a tag created while finishing the release lands
+    """
+    version = "1.2.3"
+    await check_call(
+        ["git", "checkout", "-q", "-b", "release-candidate"], cwd=test_repo_directory
+    )
+    make_empty_commit("initial", f"Release {version}", cwd=test_repo_directory)
+
+    # stand in for the release merge commit, tagged while finishing the release, leaving
+    # release-candidate behind at the release commit
+    await check_call(
+        ["git", "checkout", "-q", "-b", "release"], cwd=test_repo_directory
+    )
+    make_empty_commit("doof", "Merge release-candidate", cwd=test_repo_directory)
+    await check_call(
+        ["git", "tag", "-a", "-m", f"Release {version}", f"v{version}"],
+        cwd=test_repo_directory,
+    )
+
+    # no exception
+    await verify_release_tag(version, root=test_repo_directory)
+
+
+async def test_finish_release(mocker, test_repo_directory, test_repo):
     """finish_release should tag, merge and push the release"""
     token = "token"
     version = "version"
@@ -105,13 +178,11 @@ async def test_finish_release(mocker, timezone, test_repo_directory, test_repo):
     )
     tag_release_mock = mocker.async_patch("finish_release.tag_release")
     merge_release_mock = mocker.async_patch("finish_release.merge_release")
-    set_version_date_mock = mocker.async_patch("finish_release.set_release_date")
 
     await finish_release(
         github_access_token=token,
         repo_info=test_repo,
         version=version,
-        timezone=timezone,
     )
     validate_dependencies_mock.assert_called_once_with()
     init_working_dir_mock.assert_called_once_with(token, test_repo.repo_url)
@@ -119,51 +190,3 @@ async def test_finish_release(mocker, timezone, test_repo_directory, test_repo):
     merge_release_candidate_mock.assert_called_once_with(root=test_repo_directory)
     tag_release_mock.assert_called_once_with(version, root=test_repo_directory)
     merge_release_mock.assert_called_once_with(root=test_repo_directory)
-    set_version_date_mock.assert_called_once_with(
-        version, timezone, root=test_repo_directory
-    )
-
-
-async def test_set_release_date(test_repo_directory, timezone, mocker):
-    """set_release_date should update release notes with dates"""
-    mocker.async_patch("finish_release.check_call")
-    mocker.async_patch(
-        "finish_release.check_output", return_value=b"2018-04-27 12:00:00 +0000\n"
-    )
-    make_empty_commit("initial", "initial commit", cwd=test_repo_directory)
-    await check_call(["git", "tag", "v0.1.0"], cwd=test_repo_directory)
-    make_empty_commit("User 1", "Commit #1", cwd=test_repo_directory)
-    base_branch = "master"
-    await create_release_notes(
-        "0.1.0",
-        with_checkboxes=False,
-        base_branch=base_branch,
-        root=test_repo_directory,
-    )
-    make_empty_commit("User 2", "Commit #2", cwd=test_repo_directory)
-    await check_call(["git", "tag", "v0.2.0"], cwd=test_repo_directory)
-    await create_release_notes(
-        "0.2.0",
-        with_checkboxes=False,
-        base_branch=base_branch,
-        root=test_repo_directory,
-    )
-    await set_release_date("0.2.0", timezone, root=test_repo_directory)
-    with open(
-        os.path.join(test_repo_directory, "RELEASE.rst"), "r", encoding="utf-8"
-    ) as release_file:
-        content = release_file.read()
-    assert re.search(r"Version 0.1.0 \(Released April 27, 2018\)", content) is not None
-    today = datetime.now().strftime("%B %d, %Y")
-    assert f"Version 0.2.0 (Released {today})" in content
-
-
-async def test_set_release_date_no_file(test_repo_directory, timezone, mocker):
-    """set_release_date should exit immediately if no release file exists"""
-    mock_check = mocker.patch("finish_release.check_call", autospec=True)
-    mock_output = mocker.patch("finish_release.check_output", autospec=True)
-    mocker.patch("finish_release.os.path.isfile", return_value=False)
-    make_empty_commit("initial", "initial commit", cwd=test_repo_directory)
-    await set_release_date("0.1.0", timezone, root=test_repo_directory)
-    mock_check.assert_not_called()
-    mock_output.assert_not_called()

--- a/lib.py
+++ b/lib.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, urlunparse
 
 from dateutil.parser import parse
 
-from async_subprocess import check_call, check_output
+from async_subprocess import call, check_call, check_output
 from constants import (
     FILE_VERSION,
     SCRIPT_DIR,
@@ -395,6 +395,37 @@ async def get_default_branch(repository_path):
     ).decode()
     head_branch_line = [line for line in output.splitlines() if "HEAD branch" in line]
     return head_branch_line[0].rsplit(": ", maxsplit=1)[1]
+
+
+async def tag_exists(version, *, root):
+    """
+    Returns True if the release tag for this version already exists
+
+    Args:
+        version (str): The version of the release
+        root (str): The path to the repository
+    """
+    return (
+        await call(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/tags/v{version}"],
+            cwd=root,
+        )
+        == 0
+    )
+
+
+async def get_commit_hash(ref, *, root):
+    """
+    Returns the commit hash a ref points at, dereferencing annotated tags
+
+    Args:
+        ref (str): A git ref, for example HEAD or a tag name
+        root (str): The path to the repository
+    """
+    output = await check_output(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"], cwd=root
+    )
+    return output.decode().strip()
 
 
 @asynccontextmanager

--- a/lib_test.py
+++ b/lib_test.py
@@ -25,10 +25,11 @@ from lib import (
     reformatted_full_name,
     ReleasePR,
     remove_path_from_url,
+    tag_exists,
     url_with_access_token,
 )
 from repo_info import RepoInfo
-from test_util import async_wrapper, sync_call as call
+from test_util import async_wrapper, sync_call as call, sync_check_call
 from test_constants import FAKE_RELEASE_PR_BODY, RELEASE_PR
 
 
@@ -327,6 +328,16 @@ def test_parse_text_matching_options_error():
     with pytest.raises(Exception) as ex:
         parse_text_matching_options(["abc", "xyz"])("def")
     assert ex.value.args[0] == "Unexpected option def. Valid options: abc, xyz"
+
+
+@pytest.mark.parametrize("tagged", [True, False])
+async def test_tag_exists(test_repo_directory, tagged):
+    """tag_exists should detect whether the release tag is already in the repository"""
+    if tagged:
+        sync_check_call(["git", "tag", "v1.2.3"], cwd=test_repo_directory)
+
+    assert await tag_exists("1.2.3", root=test_repo_directory) is tagged
+    assert await tag_exists("9.9.9", root=test_repo_directory) is False
 
 
 async def test_get_default_branch(test_repo_directory):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.13"
 dependencies = [
     "packaging==25.0",
     "python-dateutil==2.9.0.post0",
-    "pytz==2025.2",
     "requests==2.34.2",
     "sentry-sdk==2.66.1",
     "tornado==6.5.7",

--- a/release.py
+++ b/release.py
@@ -15,6 +15,7 @@ from async_subprocess import (
 from constants import (
     GIT_RELEASE_NOTES_PATH,
     SCRIPT_DIR,
+    WEB_APPLICATION_TYPE,
     YARN_PATH,
 )
 from exception import (
@@ -25,6 +26,7 @@ from github import create_pr
 from lib import (
     get_default_branch,
     init_working_dir,
+    tag_exists,
 )
 from version import update_version
 
@@ -160,16 +162,45 @@ async def update_release_notes(old_version, new_version, *, base_branch, root):
     )
 
 
-async def build_release(*, root):
-    """Deploy the release candidate"""
+async def build_release(*, root, rc_tag_version=None):
+    """
+    Deploy the release candidate
+
+    Args:
+        root (str): The path to the repository
+        rc_tag_version (str): If set, the release tag is created and pushed in the same
+            atomic push as the branch, so the RC deploy can never see the branch without
+            the tag it consumes. Only the branch ref is force-updated, so an existing
+            remote tag rejects the whole push and the branch does not move.
+    """
+    if rc_tag_version is None:
+        await check_call(
+            [
+                "git",
+                "push",
+                "--force",
+                "-q",
+                "origin",
+                "release-candidate:release-candidate",
+            ],
+            cwd=root,
+        )
+        return
+
+    tag = f"v{rc_tag_version}"
+    await check_call(
+        ["git", "tag", "-a", "-m", f"Release {rc_tag_version}", tag], cwd=root
+    )
     await check_call(
         [
             "git",
             "push",
-            "--force",
+            "--atomic",
             "-q",
             "origin",
-            "release-candidate:release-candidate",
+            # `+` here is the equivalent of --force but ONLY for the branch, not the tag
+            "+release-candidate:release-candidate",
+            f"refs/tags/{tag}:refs/tags/{tag}",
         ],
         cwd=root,
     )
@@ -219,6 +250,14 @@ async def release(
     async with init_working_dir(
         github_access_token, repo_info.repo_url, branch=branch
     ) as working_dir:
+        # Web applications are tagged now rather than when the release is finished,
+        # because their release candidate deploy consumes the version tag
+        tag_upfront = repo_info.project_type == WEB_APPLICATION_TYPE
+        if tag_upfront and await tag_exists(new_version, root=working_dir):
+            raise ReleaseException(
+                f"Tag v{new_version} already exists. Tags are immutable, so this "
+                f"release needs to be cut with a new version number."
+            )
         default_branch = await get_default_branch(working_dir)
         await check_call(
             ["git", "checkout", "-qb", "release-candidate"], cwd=working_dir
@@ -245,7 +284,10 @@ async def release(
         await update_release_notes(
             old_version, new_version, base_branch=base_branch, root=working_dir
         )
-        await build_release(root=working_dir)
+        await build_release(
+            root=working_dir,
+            rc_tag_version=new_version if tag_upfront else None,
+        )
         return await generate_release_pr(
             github_access_token=github_access_token,
             repo_url=repo_info.repo_url,

--- a/release_test.py
+++ b/release_test.py
@@ -5,10 +5,13 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from constants import LIBRARY_TYPE, WEB_APPLICATION_TYPE
 from exception import ReleaseException
 from lib import url_with_access_token
+from repo_info import RepoInfo
 from release import (
     any_new_commits,
+    build_release,
     create_release_notes,
     dependency_exists,
     DependencyException,
@@ -379,9 +382,14 @@ async def test_fetch_release_hash(mocker):
     get_mock.return_value.raise_for_status.assert_called_once_with()
 
 
+@pytest.mark.parametrize("project_type", [WEB_APPLICATION_TYPE, LIBRARY_TYPE])
 @pytest.mark.parametrize("hotfix_hash", ["", "abcdef"])
-async def test_release(mocker, hotfix_hash, test_repo_directory, test_repo):
+async def test_release(
+    mocker, hotfix_hash, project_type, test_repo_directory, test_repo
+):
     """release should perform a release"""
+    test_repo = RepoInfo(**{**test_repo._asdict(), "project_type": project_type})
+    tag_upfront = project_type == WEB_APPLICATION_TYPE
     token = "token"
     old_version = "6.5.4"
     new_version = "9.8.7"
@@ -437,7 +445,7 @@ async def test_release(mocker, hotfix_hash, test_repo_directory, test_repo):
         check_call_mock.assert_any_call(
             ["git", "cherry-pick", hotfix_hash], cwd=test_repo_directory
         )
-    check_call_mock.assert_any_call(
+    plain_push = mocker.call(
         [
             "git",
             "push",
@@ -448,6 +456,113 @@ async def test_release(mocker, hotfix_hash, test_repo_directory, test_repo):
         ],
         cwd=test_repo_directory,
     )
+    atomic_push = mocker.call(
+        [
+            "git",
+            "push",
+            "--atomic",
+            "-q",
+            "origin",
+            "+release-candidate:release-candidate",
+            f"refs/tags/v{new_version}:refs/tags/v{new_version}",
+        ],
+        cwd=test_repo_directory,
+    )
+    assert (atomic_push in check_call_mock.mock_calls) is tag_upfront
+    assert (plain_push in check_call_mock.mock_calls) is not tag_upfront
+
+
+@pytest.mark.parametrize("rc_tag_version", [None, "1.2.3"])
+async def test_build_release(mocker, test_repo_directory, rc_tag_version):
+    """
+    build_release should push the branch on its own, or create the tag and push both in
+    one atomic push when the release candidate is tagged at cut time
+    """
+    check_call_mock = mocker.async_patch("release.check_call")
+
+    await build_release(root=test_repo_directory, rc_tag_version=rc_tag_version)
+
+    if rc_tag_version is None:
+        assert check_call_mock.mock_calls == [
+            mocker.call(
+                [
+                    "git",
+                    "push",
+                    "--force",
+                    "-q",
+                    "origin",
+                    "release-candidate:release-candidate",
+                ],
+                cwd=test_repo_directory,
+            )
+        ]
+    else:
+        tag = f"v{rc_tag_version}"
+        assert check_call_mock.mock_calls == [
+            mocker.call(
+                ["git", "tag", "-a", "-m", f"Release {rc_tag_version}", tag],
+                cwd=test_repo_directory,
+            ),
+            # only the branch ref is force-updated, so an existing remote tag rejects
+            # the whole push instead of silently moving
+            mocker.call(
+                [
+                    "git",
+                    "push",
+                    "--atomic",
+                    "-q",
+                    "origin",
+                    "+release-candidate:release-candidate",
+                    f"refs/tags/{tag}:refs/tags/{tag}",
+                ],
+                cwd=test_repo_directory,
+            ),
+        ]
+
+
+@pytest.mark.parametrize("project_type", [WEB_APPLICATION_TYPE, LIBRARY_TYPE])
+async def test_release_tag_already_exists(
+    mocker, project_type, test_repo_directory, test_repo
+):
+    """
+    release should refuse to cut a web application release over an existing tag, since
+    those are tagged now rather than when the release is finished and tags are immutable
+    """
+    new_version = "9.8.7"
+    test_repo = RepoInfo(**{**test_repo._asdict(), "project_type": project_type})
+    tag_upfront = project_type == WEB_APPLICATION_TYPE
+    check_call(["git", "tag", f"v{new_version}"], cwd=test_repo_directory)
+
+    mocker.async_patch("release.validate_dependencies")
+    mocker.async_patch("release.check_call")
+    mocker.async_patch("release.verify_new_commits")
+    mocker.async_patch("release.update_release_notes")
+    mocker.async_patch("release.update_version", return_value="6.5.4")
+    generate_mock = mocker.async_patch("release.generate_release_pr")
+    mocker.patch(
+        "release.init_working_dir",
+        side_effect=async_context_manager_yielder(test_repo_directory),
+    )
+
+    if tag_upfront:
+        with pytest.raises(ReleaseException) as exception:
+            await release(
+                github_access_token="token",
+                repo_info=test_repo,
+                new_version=new_version,
+            )
+        assert exception.value.args[0] == (
+            f"Tag v{new_version} already exists. Tags are immutable, so this release "
+            f"needs to be cut with a new version number."
+        )
+        generate_mock.assert_not_called()
+    else:
+        await release(
+            github_access_token="token",
+            repo_info=test_repo,
+            new_version=new_version,
+        )
+        generate_mock.assert_called_once()
 
 
 async def test_release_failed_cherry_pick(test_repo_directory, test_repo, mocker):

--- a/uv.lock
+++ b/uv.lock
@@ -296,22 +296,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
-]
-
-[[package]]
 name = "release-script"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "packaging" },
     { name = "python-dateutil" },
-    { name = "pytz" },
     { name = "requests" },
     { name = "sentry-sdk" },
     { name = "tornado" },
@@ -333,7 +323,6 @@ dev = [
 requires-dist = [
     { name = "packaging", specifier = "==25.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
-    { name = "pytz", specifier = "==2025.2" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "sentry-sdk", specifier = "==2.66.1" },
     { name = "tornado", specifier = "==6.5.7" },


### PR DESCRIPTION
> Stacked on #504 — base branch is `nl/agents-md`, not `master`. Review/merge that one first.

### What are the relevant tickets?
N/A

### Description (What does it do?)
Repos deployed to Kubernetes need the `v{version}` git tag to exist when the release candidate is cut, because the RC deploy consumes it. Today Doof creates the tag only at the very end, in [`finish_release.tag_release`](https://github.com/mitodl/release-script/blob/master/finish_release.py#L37-L43), after `release-candidate` has already merged into `release`.

- Adds an optional boolean `rc_consumes_version` to `RepoInfo`, defaulting to `False`.
- When true, `release()` creates and pushes the tag immediately after pushing the `release-candidate` branch.
- Tags are immutable for these repos, so `release()` **refuses up front** if `v{version}` already exists, rather than moving it — the release has to be re-cut with a new version number.
- `finish_release.tag_release` now skips creation when the tag already exists, and pushes either way. This is what keeps in-flight release candidates working.
- Sets the flag on the 7 k8s-deployed entries in `repos_info.json`.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Which repos, and why those.** Cross-referenced against `ol-infrastructure`'s canonical registry, [`src/bridge/settings/apps.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/apps.py) (`APPS`), corroborated by `src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py`. That registry documents itself as the single place both the Concourse k8s pipeline generator and the release bot read from, so it is the right authority rather than grepping for Deployment resources.

Flagged (7): `micromasters`, `mit-learn`, `mitxpro` (app `xpro`), `mitxonline`, `ocw-studio`, `odl-video-service`, `learn-ai`.

Deliberately not flagged, despite being `web_application` in `repos_info.json`:
- `open-discussions` — Heroku (`pulumiverse_heroku` config association), legacy
- `ocw-hugo-themes` — npm build to an S3 tarball, then Hugo to S3 + Fastly; Netlify secrets
- `bootcamp-ecommerce` — decommissioned, app dir deleted in ol-infrastructure #5018

All 7 library projects stay `False`.

Two k8s apps have no `repos_info.json` entry, so they are out of scope here: `ol-analytics-api`, and `mit-learn-nextjs` (which shares the `mit-learn` repo and is independently versioned — ol-infrastructure's registry flags that as a known wrinkle).

**`RepoInfo` compatibility.** `rc_consumes_version` is appended as the last field with `defaults=(False,)`, which requires it to be last since namedtuple defaults bind right-to-left. All 10 existing `RepoInfo(...)` construction sites are keyword or `**dict` splat — there is no positional construction anywhere in the codebase — so no call site had to change.

**`tag_exists` helper.** Added to `lib.py` next to `get_default_branch`, since both `release.py` and `finish_release.py` need it and both already import from `lib`:

```python
await call(["git", "show-ref", "--verify", "--quiet", f"refs/tags/v{version}"], cwd=root) == 0
```

`git show-ref --verify --quiet` exits 0/1 and prints nothing either way. It uses `call` rather than `check_call` so a missing tag is a return code instead of an `AsyncCalledProcessError` — the same idiom as `dependency_exists`. No extra fetch is needed because `init_working_dir` already runs `git fetch --tags -q`, so every temp clone sees all remote tags.

**Why the RC tag push uses an explicit refspec.** `release()` creates the branch with `git checkout -qb release-candidate`, which leaves no upstream, so a bare `git push` fails under `push.default=simple` (set in `init_working_dir`). `tag_release_candidate` therefore pushes `git push origin v{version}` explicitly — the same reason `build_release` already uses the explicit `release-candidate:release-candidate` refspec instead of a bare push.

**Ordering inside `release()`.** The guard runs immediately on entering `init_working_dir`, before anything is committed or pushed, so a collision costs nothing. Tag creation runs after `build_release` so the commit is on the remote branch before the tag referencing it becomes visible, and after `update_release_notes`, which is what creates the `Release X.Y.Z` commit the tag points at. The `v{old_version}`-based work (`verify_new_commits`, `update_release_notes`) reads the *previous* version's tag, so a new-version tag placed after them cannot interfere.

**Consequences worth knowing:**

- For flagged repos the tag points at the `Release X.Y.Z` commit on `release-candidate`, not at the `release` merge commit — so it excludes the `Release date for X.Y.Z` commit that `set_release_date` adds later. That is inherent to tagging at RC-cut time.
- An abandoned RC burns that version number, by design, since tags are immutable. `lib.next_versions` has no knowledge of burned versions, so `start new releases` can propose one and get refused by the new guard; the release manager then picks the next number by hand.
- Checked and unaffected: `publish.py` checks out `v{version}` as a branch, but only for library projects, which all stay `False`. `status.py`'s new-commits check compares against `origin/release-candidate` when a release PR is open, and otherwise against `v{last_version}` derived from project files on the default branch — so an early tag does not skew status.
- The `v` prefix stays hardcoded as an f-string, matching the six existing sites. A `version_tag()` helper would be a reasonable follow-up; half-migrating it here would be worse.

</details>

### How can this be tested?
Automated coverage added, all of it node-independent so it runs anywhere:

- `lib_test.py::test_tag_exists` — parameterized, creates a real `v1.2.3` tag on the fixture repo and asserts `True`/`False` correctly, including for an unrelated version.
- `lib_test.py::test_load_repos_info` — one mocked entry carries `rc_consumes_version: True` and the others omit the key, pinning both the parse path and the `False` default.
- `release_test.py::test_release` — now parameterized over `rc_consumes_version` × `hotfix_hash`; asserts the `git tag -a` and `git push origin v...` calls are present when the flag is on and **absent** when off.
- `release_test.py::test_tag_release_candidate` — asserts the exact two-call sequence.
- `release_test.py::test_release_tag_already_exists` — creates a real conflicting tag, then asserts `release()` raises `ReleaseException` with the exact message and never reaches `generate_release_pr` when the flag is on, and proceeds normally when off.
- `finish_release_test.py::test_tag_release` — parameterized over whether the tag exists; asserts creation is skipped when it does and that `git push --follow-tags` happens either way.

```
uv run ruff check     # All checks passed!
uv run pytest .       # 243 passed, 10 failed
```

The 10 failures are pre-existing and environmental, not from this branch. My shell has no `node`/`npm` on `PATH`, and every one traces to that — `env: 'node': No such file or directory` from the `git-release-notes` invocations, `DependencyException("Please install node.js")`, and `FileNotFoundError: 'npm'`. The identical 10 fail on `master`, and the passing count went **235 → 243** (+8, matching the tests added above). CI has node, so the authoritative check is the CI run on this PR — please confirm it comes back green.

Reviewer sanity check on the config edit:

```
python3 -c "
import json
d = json.load(open('repos_info.json'))
print(sorted(r['name'] for r in d['repos'] if r.get('rc_consumes_version')))
"
```

Expect exactly: `['learn-ai', 'micromasters', 'mit-learn', 'mitxonline', 'mitxpro', 'ocw-studio', 'odl-video-service']`

### Additional Context
- **Not verified from here, worth confirming before this is relied on:** the GitHub token needs permission to create tags on these repos at RC-cut time. If any of the 7 has a tag protection rule or ruleset that blocks it, the RC cut will fail on the tag push after the branch has already been pushed. Cheapest first check is cutting one RC on a single flagged repo.
- I have not exercised this end to end — that needs a real repo, a token, and push access. The first live check is one RC on a flagged repo: confirm the tag appears at cut time, then confirm `finish release` does not fail on the already-existing tag.
- `lib.py` is still not `ruff format`-clean, from a pre-existing over-long line in `load_repos_info`'s comprehension. I left it alone so it does not muddy this diff; CI only gates `ruff check`, which passes.
